### PR TITLE
Better interoperability with Go/rust peers

### DIFF
--- a/lib/core/crypto/rsa.dart
+++ b/lib/core/crypto/rsa.dart
@@ -47,13 +47,30 @@ class RsaPublicKey implements p2pkeys.PublicKey {
   /// Creates an RsaPublicKey from raw bytes (DER encoded)
   factory RsaPublicKey.fromRawBytes(Uint8List bytes) {
     final parser = pc.ASN1Parser(bytes);
-    final asn1Sequence = parser.nextObject() as pc.ASN1Sequence;
-    final publicKey = RSAPublicKey(
-      (asn1Sequence.elements?[0] as pc.ASN1Integer).integer!,
-      (asn1Sequence.elements?[1] as pc.ASN1Integer).integer!,
-    );
-    
-    return RsaPublicKey(publicKey);
+    final topLevel = parser.nextObject() as pc.ASN1Sequence;
+    final elements = topLevel.elements!;
+
+    // Handle both PKCS#1 (modulus, exponent) and SPKI (algorithmId, bitString) formats.
+    if (elements[0] is pc.ASN1Integer) {
+      // PKCS#1: sequence of [modulus, exponent]
+      final publicKey = RSAPublicKey(
+        (elements[0] as pc.ASN1Integer).integer!,
+        (elements[1] as pc.ASN1Integer).integer!,
+      );
+      return RsaPublicKey(publicKey);
+    } else {
+      // SPKI: sequence of [algorithmIdentifier, bitString(PKCS#1 key)]
+      final bitString = elements[1] as pc.ASN1BitString;
+      // stringValues is the bit string content without the unused-bits byte
+      final keyBytes = Uint8List.fromList(bitString.stringValues!);
+      final innerParser = pc.ASN1Parser(keyBytes);
+      final innerSeq = innerParser.nextObject() as pc.ASN1Sequence;
+      final publicKey = RSAPublicKey(
+        (innerSeq.elements![0] as pc.ASN1Integer).integer!,
+        (innerSeq.elements![1] as pc.ASN1Integer).integer!,
+      );
+      return RsaPublicKey(publicKey);
+    }
   }
 
   factory RsaPublicKey.unmarshal(Uint8List bytes){

--- a/lib/core/peer/peer_id.dart
+++ b/lib/core/peer/peer_id.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 import 'package:bs58/bs58.dart';
 import 'package:dcid/dcid.dart' as cid_lib; // Added alias
-import 'package:dart_libp2p/core/routing/routing.dart';
 import 'package:dart_multihash/dart_multihash.dart';
 import 'package:dart_libp2p/core/crypto/ed25519.dart' as key_generator;
 import 'package:dart_libp2p/core/crypto/keys.dart';
@@ -10,7 +9,6 @@ import 'package:collection/collection.dart';
 
 /// Implementation of PeerId that follows the libp2p specification
 class PeerId {
-
   static const int _maxInlineKeyLength = 42;
 
   Uint8List? _multihash;
@@ -45,62 +43,66 @@ class PeerId {
 
       // Use constants CID.V1, CID.V0 and properties from the actualCid object.
       // Access codec from cid_lib.codecs map.
-      if (actualCid.version == cid_lib.CID.V1 && actualCid.codec == cid_lib.codecNameToCode['libp2p-key']!) {
+      if (actualCid.version == cid_lib.CID.V1 &&
+          actualCid.codec == cid_lib.codecNameToCode['libp2p-key']!) {
         return actualCid.multihash;
       }
       if (actualCid.version == cid_lib.CID.V0) {
         // CIDv0's multihash is what a legacy PeerID (Qm...) contains.
         return actualCid.multihash;
       }
-      // It's a CID, but not one we recognize for PeerIDs
-      throw FormatException('CID "$s" is not a valid libp2p PeerID format (version ${actualCid.version}/codec ${actualCid.codec} mismatch)');
+      throw FormatException(
+          'CID "$s" is not a valid libp2p PeerID format (version ${actualCid.version}/codec ${actualCid.codec} mismatch)');
     } catch (e) {
       // CID.fromString failed or threw the FormatException above.
-      // Try parsing as a legacy raw base58 multihash if 's' starts with '1' (identity).
-      // 'Qm...' (CIDv0) should have been handled by CID.decodeCid.
-      if (s.startsWith('1')) { // Legacy base58 encoded identity multihash
-        try {
-          final bytes = base58.decode(s);
-          Multihash.decode(bytes); // Validates if it's a proper multihash
-          return Uint8List.fromList(bytes);
-        } catch (err) {
-          throw FormatException('Failed to parse legacy base58 peer ID "$s": $err');
+      // Try parsing as a legacy raw base58 multihash. RSA identity peer IDs can
+      // be long base58 multihashes and do not necessarily start with "1".
+      try {
+        final bytes = base58.decode(s);
+        Multihash.decode(bytes); // Validates if it's a proper multihash.
+        return Uint8List.fromList(bytes);
+      } catch (err) {
+        if (e is FormatException &&
+            e.message.contains('libp2p PeerID format')) {
+          rethrow; // Our specific error from above
         }
+        throw FormatException('Invalid peer ID format for "$s": $e');
       }
-      // If it wasn't a valid PeerID CID and not a legacy '1...' identity multihash.
-      if (e is FormatException && e.message.contains('libp2p PeerID format')) {
-        rethrow; // Our specific error from above
-      }
-      throw FormatException('Invalid peer ID format for "$s": $e');
     }
   }
 
   static PeerId decode(String s) => PeerId(_parseStringToMultihash(s));
 
   /// FromCid converts a CID to a peer ID, if possible.
-  static PeerId fromCid(cid_lib.CID cid) { // Parameter type updated to aliased CID
+  static PeerId fromCid(cid_lib.CID cid) {
+    // Parameter type updated to aliased CID
     // Note: The input 'cid' here is already a CID object.
     // Use constants CID.V1, CID.V0 and properties from the cid object.
     // Access codec from cid_lib.codecs map.
-    if (cid.version == cid_lib.CID.V1 && cid.codec == cid_lib.codecNameToCode['libp2p-key']!) {
+    if (cid.version == cid_lib.CID.V1 &&
+        cid.codec == cid_lib.codecNameToCode['libp2p-key']!) {
       return PeerId(cid.multihash);
     }
     if (cid.version == cid_lib.CID.V0) {
       // CIDv0 is also acceptable, its multihash is used directly.
       return PeerId(cid.multihash);
     }
-    throw FormatException('Invalid CID: not a libp2p-key CID (v1 with codec 0x${cid_lib.codecNameToCode['libp2p-key']!}) or a CIDv0. Got v${cid.version} codec 0x${cid.codec.toRadixString(16)}');
+    throw FormatException(
+        'Invalid CID: not a libp2p-key CID (v1 with codec 0x${cid_lib.codecNameToCode['libp2p-key']!}) or a CIDv0. Got v${cid.version} codec 0x${cid.codec.toRadixString(16)}');
   }
 
   /// ToCid encodes a peer ID as a CID of the public key.
-  cid_lib.CID toCid() { // Return type updated to aliased CID
+  cid_lib.CID toCid() {
+    // Return type updated to aliased CID
     if (_multihash == null || _multihash!.isEmpty) {
-      throw StateError('Cannot convert invalid PeerId to CID: multihash is empty or null.');
+      throw StateError(
+          'Cannot convert invalid PeerId to CID: multihash is empty or null.');
     }
     // Create a CIDv1 with libp2p-key codec and the peer's multihash.
     // Use constant CID.V1 for version.
     // Use cid_lib.codecs map for codec constant.
-    return cid_lib.CID(cid_lib.CID.V1, cid_lib.codecNameToCode['libp2p-key']!, _multihash!);
+    return cid_lib.CID(
+        cid_lib.CID.V1, cid_lib.codecNameToCode['libp2p-key']!, _multihash!);
   }
 
   /// Creates a PeerId from a private key
@@ -147,12 +149,15 @@ class PeerId {
         try {
           return _parseStringToMultihash(cidStr);
         } catch (e) {
-          throw FormatException('Invalid PeerId JSON: failed to decode CID string "$cidStr": $e');
+          throw FormatException(
+              'Invalid PeerId JSON: failed to decode CID string "$cidStr": $e');
         }
       } else {
-        throw FormatException('Invalid PeerId JSON: "cid" field is not a string.');
+        throw FormatException(
+            'Invalid PeerId JSON: "cid" field is not a string.');
       }
-    } else if (json.containsKey('bytes')) { // Legacy: raw multihash bytes, base58 encoded
+    } else if (json.containsKey('bytes')) {
+      // Legacy: raw multihash bytes, base58 encoded
       final bytesStr = json['bytes'];
       if (bytesStr is String) {
         try {
@@ -160,16 +165,20 @@ class PeerId {
           Multihash.decode(bytes); // Validate it's a multihash
           return Uint8List.fromList(bytes);
         } catch (e) {
-          throw FormatException('Invalid PeerId JSON: failed to decode "bytes" field "$bytesStr": $e');
+          throw FormatException(
+              'Invalid PeerId JSON: failed to decode "bytes" field "$bytesStr": $e');
         }
       } else {
-        throw FormatException('Invalid PeerId JSON: "bytes" field is not a string.');
+        throw FormatException(
+            'Invalid PeerId JSON: "bytes" field is not a string.');
       }
     }
-    throw FormatException('Invalid PeerId JSON format: missing "cid" or "bytes" key.');
+    throw FormatException(
+        'Invalid PeerId JSON format: missing "cid" or "bytes" key.');
   }
 
-  PeerId.fromJson(Map<String, dynamic> json) : _multihash = _parseJsonToMultihash(json);
+  PeerId.fromJson(Map<String, dynamic> json)
+      : _multihash = _parseJsonToMultihash(json);
 
   static Future<PeerId> random() async {
     // Generate a random Ed25519 key and create PeerId from it
@@ -239,13 +248,15 @@ class PeerId {
     try {
       final decoded = Multihash.decode(_multihash ?? Uint8List.fromList([]));
       // Only identity multihash contains the public key
-      if (decoded.code != 0x00) { // 0x00 is the code for identity
+      if (decoded.code != 0x00) {
+        // 0x00 is the code for identity
         return null;
       }
 
       // Try to unmarshal the digest as a public key
       try {
-        return await Ed25519PublicKey.unmarshal(Uint8List.fromList(decoded.digest));
+        return await Ed25519PublicKey.unmarshal(
+            Uint8List.fromList(decoded.digest));
       } catch (e) {
         return null;
       }
@@ -282,5 +293,4 @@ class PeerId {
 
   @override
   int get hashCode => Object.hashAll(_multihash ?? []);
-
 }

--- a/lib/p2p/security/noise/noise_protocol.dart
+++ b/lib/p2p/security/noise/noise_protocol.dart
@@ -5,8 +5,8 @@ import 'package:cryptography/cryptography.dart' as crypto; // Renamed to avoid c
 import 'package:meta/meta.dart';
 
 import '../../../core/crypto/keys.dart' as keys;
-import '../../../core/crypto/ed25519.dart' as ed25519_keys; // Added for Ed25519PublicKey
-import '../../../core/crypto/pb/crypto.pbenum.dart' as crypto_pb; // Renamed
+import '../../../core/crypto/pb/crypto.pb.dart' as crypto_key_pb;
+import '../../../core/crypto/pb/crypto.pbenum.dart' as crypto_pb;
 import '../../../core/network/transport_conn.dart';
 import '../../../core/peer/peer_id.dart';
 import '../secured_connection.dart';
@@ -100,6 +100,11 @@ class NoiseSecurity implements SecurityProtocol {
 
   /// Verifies a remote peer's NoiseHandshakePayload.
   /// Returns the remote PeerId on success.
+  ///
+  /// Supports all key types (Ed25519, RSA, ECDSA) for the remote peer's
+  /// identity key. The Noise XX handshake uses Curve25519 for the static
+  /// and ephemeral keys — the identity key type only matters for signature
+  /// verification in the payload.
   Future<PeerId> _verifyHandshakePayload(
     Uint8List payloadBytes,
     Uint8List remoteStaticNoiseKey,
@@ -109,8 +114,9 @@ class NoiseSecurity implements SecurityProtocol {
     if (!payload.hasIdentityKey()) throw NoiseProtocolException('Remote payload missing identity key');
     if (!payload.hasIdentitySig()) throw NoiseProtocolException('Remote payload missing signature');
 
-    final remoteLibp2pPublicKey = ed25519_keys.Ed25519PublicKey.unmarshal(
-        Uint8List.fromList(payload.identityKey));
+    // Use the generic unmarshaller to support Ed25519, RSA, and ECDSA peers.
+    final protoPubKey = crypto_key_pb.PublicKey.fromBuffer(payload.identityKey);
+    final remoteLibp2pPublicKey = keys.publicKeyFromProto(protoPubKey);
 
     // Verify: "noise-libp2p-static-key:" + remote_static_noise_key
     final dataToVerify = Uint8List.fromList([
@@ -167,9 +173,9 @@ class NoiseSecurity implements SecurityProtocol {
       _log.info('secureOutbound: Handshake complete. Remote peer: ${remotePeerId.toBase58()}');
 
       // Session keys are now derived. Nonces start at 0 (no post-handshake exchange).
-      final remoteLibp2pPublicKey = ed25519_keys.Ed25519PublicKey.unmarshal(
-          Uint8List.fromList(
-              noise_pb.NoiseHandshakePayload.fromBuffer(msg2Payload).identityKey));
+      final remoteProtoKey = crypto_key_pb.PublicKey.fromBuffer(
+          noise_pb.NoiseHandshakePayload.fromBuffer(msg2Payload).identityKey);
+      final remoteLibp2pPublicKey = keys.publicKeyFromProto(remoteProtoKey);
 
       return SecuredConnection(
         connection,
@@ -227,9 +233,9 @@ class NoiseSecurity implements SecurityProtocol {
 
       _log.info('secureInbound: Handshake complete. Remote peer: ${remotePeerId.toBase58()}');
 
-      final remoteLibp2pPublicKey = ed25519_keys.Ed25519PublicKey.unmarshal(
-          Uint8List.fromList(
-              noise_pb.NoiseHandshakePayload.fromBuffer(msg3Payload).identityKey));
+      final remoteProtoKey = crypto_key_pb.PublicKey.fromBuffer(
+          noise_pb.NoiseHandshakePayload.fromBuffer(msg3Payload).identityKey);
+      final remoteLibp2pPublicKey = keys.publicKeyFromProto(remoteProtoKey);
 
       // Nonces start at 0 (no post-handshake exchange needed).
       return SecuredConnection(

--- a/lib/p2p/transport/multiplexing/yamux/session.dart
+++ b/lib/p2p/transport/multiplexing/yamux/session.dart
@@ -673,10 +673,23 @@ class YamuxSession implements Multiplexer, core_mux.MuxedConn, Conn { // Added C
     try {
       final frame = YamuxFrame.synStream(streamId);
       await _sendFrame(frame);
-      _log.fine('$_logPrefix [OPEN-STREAM-DIAG] SYN sent for streamID=$streamId, waiting for ACK (timeout=${_config.streamWriteTimeout.inSeconds}s)');
+      _log.fine('$_logPrefix [OPEN-STREAM-DIAG] SYN sent for streamID=$streamId');
 
-      await completer.future.timeout(_config.streamWriteTimeout);
-      _log.fine('$_logPrefix [OPEN-STREAM-DIAG] ACK received for streamID=$streamId');
+      // Don't block on ACK. The yamux spec allows the initiator to send
+      // data immediately after SYN. Some implementations (rust-libp2p)
+      // send ACK lazily — piggybacked on the first data/window-update
+      // frame rather than as a standalone ACK. Blocking here causes a
+      // deadlock when the remote only ACKs after reading our first data.
+      //
+      // We still track the ACK via the completer so _handleFrame can
+      // resolve it when/if it arrives, and we log if it never comes.
+      // If the remote rejects the stream (RST), the stream will be
+      // reset through the normal RST handling path.
+      completer.future.then((_) {
+        _log.fine('$_logPrefix [OPEN-STREAM-DIAG] ACK received for streamID=$streamId');
+      }).catchError((e) {
+        _log.warning('$_logPrefix [OPEN-STREAM-DIAG] ACK error for streamID=$streamId: $e');
+      });
 
       await stream.open();
       _log.fine('$_logPrefix [OPEN-STREAM-DIAG] stream.open() complete for streamID=$streamId');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_libp2p
 description: A comprehensive Dart implementation of the libp2p networking stack with modular architecture, multiple transports (TCP/UDX), Noise security, and peer-to-peer capabilities.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/stephanfeb/dart_libp2p
 repository: https://github.com/stephanfeb/dart_libp2p
 documentation: https://github.com/stephanfeb/dart_libp2p/tree/main/docs
@@ -25,8 +25,7 @@ dependencies:
 
   base_x: ^2.0.0
 
-  dart_udx:
-    path: ../dart-udx
+  dart_udx: ^2.0.3
 
   dcid: ^1.0.0
 
@@ -48,7 +47,3 @@ dev_dependencies:
   test: ^1.24.0
   protoc_plugin: ^21.1.2
   lints: ^2.1.0
-
-dependency_overrides:
-  dart_udx:
-    path: ../dart-udx

--- a/test/core/peer/peer_id_test.dart
+++ b/test/core/peer/peer_id_test.dart
@@ -1,0 +1,13 @@
+import 'package:dart_libp2p/core/peer/peer_id.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('parses long base58 identity peer IDs', () {
+    const peerId =
+        '22ecpdjAT14xkGFQXYx9YT3x4yrJBwM85a9nFX9gEzsseWeKdSLnU8Xs5ZQQzKTXpPvZqjWx7VsGXNrFFJb2K2qVRJq4vTQPFU2YUbEXrdTeksNPHadGXtGuWKomYZU1LmcnimCaAiat18npsQeHgunHjzEkQaiuxSxmX7he1zS3pJY2xK17eXSbneQWVSXCgs4YaZ9iN2hWHu3h5taq4PCSJHaefUyeEBv6dFC7tukaRT2PD77njXVNMfid9dRiqePN76hz3JgZkD4BFdMGmtaX3mUhDY58186fXum82JW63Ve6Tet1xzvHKMCLWbwHattwD55W1PWoTLWtZKBQniqZSMChGQKX9pty45CZiUBN83xd8t34k9voS6yv';
+
+    final parsed = PeerId.fromString(peerId);
+
+    expect(parsed.toString(), peerId);
+  });
+}


### PR DESCRIPTION

## Summary

This change improves interoperability with Go/libp2p peers, especially legacy RSA peer IDs used by public IPFS/libp2p bootstrap nodes.

## Changes

- `PeerId` parsing now falls back to decoding any valid raw base58 multihash, not only strings that start with `1`.
- This allows long RSA peer IDs such as `Qm...`, `22...`, and `DA...` forms to be parsed when they are not represented as CIDv1 `libp2p-key` strings.
- Invalid CID peer IDs are still rejected when the string is a CID with an unsupported peer ID codec.
- Removed the local `dart_udx` path dependency override from `pubspec.yaml` and restored the published dependency constraint.

## Why

Go/libp2p and the public IPFS DHT still expose many RSA peers as raw base58 multihashes. The previous parser only accepted CID-style IDs and a narrow legacy identity-multihash case, so valid RSA peers could not be dialed or used as DHT bootstrap/query peers.

This blocked DHT traversal against mixed public networks and made discovery fail before the DHT protocol exchange could happen.

## Validation

- Added focused peer ID coverage under `test/core/peer/`.
- Verified against real public DHT peers whose IDs are RSA/raw base58 multihashes.