### PR TITLE
Fix DCUtR simultaneous-connect: four independent bugs blocking Dart↔Go hole-punch

### DIFF
--- a/lib/core/network/context.dart
+++ b/lib/core/network/context.dart
@@ -47,9 +47,14 @@ class Context {
 
   /// Gets the force direct dial option from the Context
   (bool, String) getForceDirectDial() {
+    // Callers store this key as either a bool (e.g. holepunch/service.dart's
+    // `true`) or a String reason (e.g. holepuncher.dart). The unconditional
+    // `as String` cast below threw a TypeError for bool-valued callers,
+    // silently discarding the force-direct-dial signal on that path. Accept
+    // either representation.
     final value = getValue(_forceDirectDialKey);
     if (value != null) {
-      return (true, value as String);
+      return (true, value is String ? value : value.toString());
     }
     return (false, '');
   }

--- a/lib/p2p/host/basic/basic_host.dart
+++ b/lib/p2p/host/basic/basic_host.dart
@@ -379,7 +379,13 @@ class BasicHost implements Host {
       _holePunchService = holepunch_impl.HolePunchServiceImpl(
         this,
         _idService, // Pass the existing IDService instance
-        () => publicAddrs, // Pass a function that returns only public/observed addrs
+        // `publicAddrs` only reflects observed/AutoNAT-confirmed addresses,
+        // so it misses addresses injected via the host's AddrsFactory (e.g.
+        // an operator-supplied external address on a host AutoNAT can't
+        // observe directly). Use `addrs` (which already runs AddrsFactory)
+        // minus relay addresses instead, so HolePunchService advertises
+        // those addresses too.
+        () => addrs.where((a) => !isRelayAddress(a)).toList(),
         options: const holepunch_impl.HolePunchOptions(), // Default options for now
       );
       await _holePunchService!.start(); // Call start as per its interface
@@ -1045,7 +1051,16 @@ class BasicHost implements Host {
 
     final filterStartTime = DateTime.now();
     
-    final filteredAddrs = _addrsFactory(pi.addrs);
+    // _addrsFactory transforms how THIS host presents its OWN addresses to
+    // others (see `get addrs => _addrsFactory(allAddrs)` above) — it must
+    // never run on `pi.addrs`, the addresses of the PEER being connected to.
+    // The original code called it here anyway, so every connect() to any
+    // peer (relay, hole-punch target, anyone) appended this host's own
+    // AddrsFactory-derived addresses into THAT PEER's peerstore entry.
+    // Swarm.dialPeer then raced this host's own address as a bogus dial
+    // candidate for every subsequent dial to that peer — observed as a host
+    // attempting to dial its own external address.
+    final filteredAddrs = pi.addrs;
 
     
     await peerStore.addrBook.addAddrs(pi.id, filteredAddrs, Duration(minutes: 5));
@@ -1057,8 +1072,15 @@ class BasicHost implements Host {
 
     final connectedness = _network.connectedness(pi.id);
 
-    
-    if (connectedness == Connectedness.connected) {
+    // This early return fires even for a *relay* connection
+    // (Connectedness.limited-worthy, but connectedness() doesn't distinguish
+    // it from a full connection here) — meaning DCUtR's forceDirectDial punch
+    // dial never even reached Swarm.dialPeer (where its own forceDirectDial
+    // check applies). ForceDirectDial's entire purpose is "dial anyway, even
+    // though a connection exists" — honor that here, one layer up from where
+    // it was already checked.
+    final skipEarlyReturn = context?.getForceDirectDial().$1 ?? false;
+    if (connectedness == Connectedness.connected && !skipEarlyReturn) {
       final totalTime = DateTime.now().difference(startTime);
 
       return;

--- a/lib/p2p/network/swarm/swarm.dart
+++ b/lib/p2p/network/swarm/swarm.dart
@@ -786,11 +786,24 @@ class Swarm implements Network {
         }
       }
       
-      if (healthyConns.isNotEmpty) {
+      // forceDirectDial is set by holepunch/service.dart and holepuncher.dart
+      // on every punch dial, but nothing in this function previously read it
+      // — DCUtR's entire precondition is an existing RELAY connection, so
+      // dialPeer always returned that relay connection here and the punch
+      // dial below (which would actually reach the transport) never ran.
+      // Only skip the short-circuit when every existing healthy connection
+      // is relayed; an already-direct connection is left alone.
+      final forceDirectDial = context.getForceDirectDial().$1;
+      final onlyRelayed = healthyConns.isNotEmpty &&
+          healthyConns.every((c) => c.remoteMultiaddr.hasProtocol('p2p-circuit'));
+
+      if (healthyConns.isNotEmpty && !(forceDirectDial && onlyRelayed)) {
         // Prefer newest connection - more likely to be alive for relayed paths
         // where the end-to-end path can break without local detection
         _logger.warning('Swarm.dialPeer: Found healthy connection for peer ${peerId.toString()}. Returning newest connection ID: ${healthyConns.last.id}');
         return healthyConns.last;
+      } else if (healthyConns.isNotEmpty) {
+        _logger.fine('Swarm.dialPeer: forceDirectDial set and only relayed connection(s) exist for ${peerId.toString()} — dialing fresh addresses instead of reusing the relay connection.');
       } else {
         _logger.warning('Swarm.dialPeer: No healthy connections found for peer ${peerId.toString()}. Will create new connection.');
       }
@@ -1005,8 +1018,13 @@ class Swarm implements Network {
       }
     }
 
-    // Dial the address
-    final transportConn = await transport.dial(dialAddr);
+    // Dial the address. forceDirectDial marks a DCUtR punch attempt, which
+    // hole-punch-capable transports (e.g. UDX) use to dial from the same
+    // socket whose NAT mapping was already advertised to the peer.
+    final transportConn = await transport.dial(
+      dialAddr,
+      simultaneousConnect: context.getForceDirectDial().$1,
+    );
     
     // Upgrade the connection
     final upgradedConn = await _upgrader.upgradeOutbound(

--- a/lib/p2p/protocol/circuitv2/client/client.dart
+++ b/lib/p2p/protocol/circuitv2/client/client.dart
@@ -295,7 +295,7 @@ class CircuitV2Client implements Transport {
 
 
   @override
-  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout}) async {
+  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout, bool simultaneousConnect = false}) async {
     _log.info('[CircuitV2Client.dial] 🔌 Starting circuit dial to $addr');
     
     // 1. Parse the /p2p-circuit address.

--- a/lib/p2p/transport/tcp_transport.dart
+++ b/lib/p2p/transport/tcp_transport.dart
@@ -40,7 +40,7 @@ class TCPTransport implements Transport {
        _connManager = connManager ?? ConnectionManager();
 
   @override
-  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout}) async {
+  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout, bool simultaneousConnect = false}) async {
     final host = addr.valueForProtocol('ip4') ?? addr.valueForProtocol('ip6');
     final port = int.parse(addr.valueForProtocol('tcp') ?? '0');
 

--- a/lib/p2p/transport/transport.dart
+++ b/lib/p2p/transport/transport.dart
@@ -10,9 +10,16 @@ abstract class Transport {
   /// The configuration for this transport
   TransportConfig get config;
 
-  /// Dials a peer at the given multiaddress with optional timeout override
-  /// Returns a connection to the peer if successful
-  Future<Conn> dial(MultiAddr addr, {Duration? timeout});
+  /// Dials a peer at the given multiaddress with optional timeout override.
+  /// Returns a connection to the peer if successful.
+  ///
+  /// [simultaneousConnect] signals that this dial is a DCUtR
+  /// simultaneous-connect (hole-punch) attempt rather than an ordinary dial.
+  /// Transports that support NAT hole-punching may use this to change how
+  /// the dial is performed — e.g. reusing an active listener's socket so
+  /// the dial originates from the address already advertised to the peer.
+  /// Transports that don't support hole-punching may ignore it.
+  Future<Conn> dial(MultiAddr addr, {Duration? timeout, bool simultaneousConnect = false});
 
   /// Starts listening on the given multiaddress
   /// Returns a listener that can accept incoming connections

--- a/lib/p2p/transport/udx_transport.dart
+++ b/lib/p2p/transport/udx_transport.dart
@@ -44,6 +44,17 @@ class UDXTransport implements Transport {
   final Set<UDXSessionConn> _activeDialerConns = {};
   // static int _nextDialStreamIdPairBase = 1; // Removed static counter
 
+  // The multiplexer(s) backing this transport's active listener(s), keyed by
+  // IP family (true = IPv6, false = IPv4). DCUtR's simultaneous-connect
+  // requires the punch dial to originate from the SAME local socket whose
+  // external NAT mapping was already advertised in the CONNECT message — a
+  // fresh ephemeral dial socket gets a different, unadvertised mapping and
+  // the punch times out. When a listener is active for the target's address
+  // family, _performDial reuses its multiplexer (dart_udx routes by CID, so
+  // one physical socket safely hosts both the listener's inbound sessions
+  // and this outbound dial).
+  final Map<bool, UDXMultiplexer> _listenerMultiplexers = {};
+
   /// Optional metrics observer for UDX transport events
   UdxMetricsObserver? metricsObserver;
   
@@ -68,8 +79,8 @@ class UDXTransport implements Transport {
   }
 
   @override
-  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout}) async {
-    _logger.fine('[UDXTransport.dial] Attempting to dial $addr with timeout: ${timeout ?? config.dialTimeout}');
+  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout, bool simultaneousConnect = false}) async {
+    _logger.fine('[UDXTransport.dial] Attempting to dial $addr with timeout: ${timeout ?? config.dialTimeout}, simultaneousConnect: $simultaneousConnect');
     final host = addr.valueForProtocol('ip4') ?? addr.valueForProtocol('ip6');
     final port = int.parse(addr.valueForProtocol('udp') ?? '0');
 
@@ -78,10 +89,10 @@ class UDXTransport implements Transport {
     }
 
     final effectiveTimeout = timeout ?? config.dialTimeout;
-    
+
     // Use UDX exception handler with retry logic for the entire dial operation
     return await UDXExceptionHandler.handleUDXOperation(
-      () => _performDial(addr, host, port, effectiveTimeout),
+      () => _performDial(addr, host, port, effectiveTimeout, simultaneousConnect),
       'UDXTransport.dial($addr)',
       retryConfig: UDXRetryConfig.regular,
     );
@@ -89,36 +100,62 @@ class UDXTransport implements Transport {
 
   /// Performs the actual dial operation with comprehensive resource cleanup
   Future<TransportConn> _performDial(
-    MultiAddr addr, 
-    String host, 
-    int port, 
+    MultiAddr addr,
+    String host,
+    int port,
     Duration effectiveTimeout,
+    bool simultaneousConnect,
   ) async {
     RawDatagramSocket? rawSocket;
     UDXMultiplexer? multiplexer;
     UDPSocket? udpSocket;
     UDXStream? initialStream;
-    
-    try {
-      _logger.fine('[UDXTransport._performDial] Creating RawDatagramSocket for $host');
-      
-      // Create raw UDP socket and bind it with UDX exception handling
-      final isIPv6 = UDX.getAddressFamily(host) == 6;
-      rawSocket = await UDXExceptionHandler.handleUDXOperation(
-        () => RawDatagramSocket.bind(
-          isIPv6 ? InternetAddress.anyIPv6 : InternetAddress.anyIPv4, 
-          0
-        ),
-        'RawDatagramSocket.bind($host)',
-      );
-      _logger.fine('[UDXTransport._performDial] RawDatagramSocket bound to: ${rawSocket!.address.address}:${rawSocket!.port}');
+    // True when this call created its own rawSocket/multiplexer and is
+    // therefore responsible for tearing it down on failure. When reusing a
+    // listener's multiplexer, ownership stays with that listener.
+    bool ownsMultiplexer = false;
 
-      // Create multiplexer with exception handling
-      multiplexer = await UDXExceptionHandler.handleUDXOperation(
-        () async => UDXMultiplexer(rawSocket!, metricsObserver: metricsObserver),
-        'UDXMultiplexer.create',
-      );
-      _logger.fine('[UDXTransport._performDial] UDXMultiplexer created');
+    try {
+      // DCUtR's simultaneous-connect requires the punch dial to originate
+      // from the SAME local socket whose external NAT mapping was already
+      // advertised in the CONNECT message — a fresh ephemeral dial socket
+      // gets a different, unadvertised mapping and the punch times out. When
+      // a listener is active for the target's address family AND this dial
+      // is itself a simultaneous-connect attempt, reuse the listener's
+      // multiplexer instead of binding a new socket (dart_udx routes by CID,
+      // so one physical socket safely hosts both the listener's inbound
+      // sessions and this outbound dial). Gating on simultaneousConnect
+      // keeps ordinary dials — including a transport dialing its own
+      // active listener, as in-process tests do — on their own fresh
+      // socket, where they belong.
+      final isIPv6 = UDX.getAddressFamily(host) == 6;
+      final reused = simultaneousConnect ? _listenerMultiplexers[isIPv6] : null;
+
+      if (reused != null) {
+        _logger.fine('[UDXTransport._performDial] Reusing active listener multiplexer (${reused.socket.address.address}:${reused.socket.port}) for dial to $host:$port — required for DCUtR simultaneous-connect.');
+        multiplexer = reused;
+        ownsMultiplexer = false;
+      } else {
+        _logger.fine('[UDXTransport._performDial] No active listener for this address family; creating RawDatagramSocket for $host');
+
+        // Create raw UDP socket and bind it with UDX exception handling
+        rawSocket = await UDXExceptionHandler.handleUDXOperation(
+          () => RawDatagramSocket.bind(
+            isIPv6 ? InternetAddress.anyIPv6 : InternetAddress.anyIPv4,
+            0
+          ),
+          'RawDatagramSocket.bind($host)',
+        );
+        _logger.fine('[UDXTransport._performDial] RawDatagramSocket bound to: ${rawSocket!.address.address}:${rawSocket!.port}');
+
+        // Create multiplexer with exception handling
+        multiplexer = await UDXExceptionHandler.handleUDXOperation(
+          () async => UDXMultiplexer(rawSocket!, metricsObserver: metricsObserver),
+          'UDXMultiplexer.create',
+        );
+        ownsMultiplexer = true;
+        _logger.fine('[UDXTransport._performDial] UDXMultiplexer created');
+      }
 
       // Create UDPSocket through multiplexer with exception handling
       udpSocket = await UDXExceptionHandler.handleUDXOperation(
@@ -205,8 +242,9 @@ class UDXTransport implements Transport {
         }
       }
 
-      final localProtocol = rawSocket.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
-      final localMa = MultiAddr('/$localProtocol/${rawSocket.address.address}/udp/${rawSocket.port}/udx');
+      final localSocket = multiplexer!.socket;
+      final localProtocol = localSocket.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+      final localMa = MultiAddr('/$localProtocol/${localSocket.address.address}/udp/${localSocket.port}/udx');
       final remoteMa = addr;
 
       _logger.fine('[UDXTransport._performDial] Creating UDXSessionConn for $addr. Local: $localMa, Remote: $remoteMa');
@@ -231,13 +269,16 @@ class UDXTransport implements Transport {
     } catch (error) {
       _logger.warning('[UDXTransport._performDial] Error during dial to $addr: $error. Performing cleanup.');
       
-      // Comprehensive resource cleanup using UDXExceptionUtils
+      // Comprehensive resource cleanup using UDXExceptionUtils.
+      // Only close the multiplexer/rawSocket if this dial created them — a
+      // reused listener multiplexer must keep serving that listener's
+      // inbound sessions after a failed dial attempt.
       await UDXExceptionUtils.safeCloseAll({
         'initialStream': () async => await initialStream?.close(),
-        'multiplexer': () async => multiplexer?.close(),
-        'rawSocket': () async => rawSocket?.close(),
+        if (ownsMultiplexer) 'multiplexer': () async => multiplexer?.close(),
+        if (ownsMultiplexer) 'rawSocket': () async => rawSocket?.close(),
       });
-      
+
       rethrow; // Let UDXExceptionHandler handle the retry logic
     }
   }
@@ -269,7 +310,13 @@ class UDXTransport implements Transport {
       multiplexer = UDXMultiplexer(rawSocket, metricsObserver: metricsObserver);
       _logger.fine('[UDXTransport.listen] UDXMultiplexer created');
 
-      final protocol = rawSocket.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+      final isIPv6 = rawSocket.address.type == InternetAddressType.IPv6;
+      // Register this listener's multiplexer so a subsequent DCUtR punch
+      // dial to a peer of the same address family reuses this socket's NAT
+      // mapping instead of opening a fresh, unadvertised one.
+      _listenerMultiplexers[isIPv6] = multiplexer;
+
+      final protocol = isIPv6 ? 'ip6' : 'ip4';
       final boundMa = MultiAddr('/$protocol/${rawSocket.address.address}/udp/${rawSocket.port}/udx');
       _logger.fine('[UDXTransport.listen] Creating UDXListener for $boundMa');
       final listener = UDXListener(
@@ -323,6 +370,7 @@ class UDXTransport implements Transport {
       }
     }
     _activeListeners.clear();
+    _listenerMultiplexers.clear();
     _logger.fine('[UDXTransport.dispose] All active listeners closed and cleared.');
 
     for (final conn in _activeDialerConns.toList()) { 
@@ -555,9 +603,16 @@ class UDXSessionConn implements MuxedConn, TransportConn {
     final expectedRemoteHost = _remoteMultiaddr.valueForProtocol(remoteAddress.type == InternetAddressType.IPv4 ? 'ip4' : 'ip6');
     final expectedRemotePort = int.parse(_remoteMultiaddr.valueForProtocol('udp')!);
 
-    if (remoteAddress.address != expectedRemoteHost || remotePort != expectedRemotePort) {
+    // Accept on port-only match as a fallback. Through NAT, the source IP a
+    // punch/new-stream packet actually arrives from can differ from what was
+    // advertised (the peer's NAT may egress a different address than the one
+    // it's mapped as); the port is the more reliable identifier here.
+    if (remotePort != expectedRemotePort) {
       _logger.fine('[UDXSessionConn $id] (Dialer): Received unmatched packet from unexpected source ${remoteAddress.address}:$remotePort. Expected $expectedRemoteHost:$expectedRemotePort. Ignoring.');
       return;
+    }
+    if (remoteAddress.address != expectedRemoteHost) {
+      _logger.info('[UDXSessionConn $id] (Dialer): Accepting unmatched packet on port-only match — source IP ${remoteAddress.address} differs from expected $expectedRemoteHost (through-NAT discrepancy), port $remotePort matches.');
     }
     
     try {


### PR DESCRIPTION
# Fix DCUtR simultaneous-connect: four independent bugs blocking Dart↔Go hole-punch

Fixes #15. See that issue for the full writeup of each bug; this description covers what changed and how it was verified.

## Commits

1. **`fix: Context.getForceDirectDial() throws for bool-valued callers`** — accept both bool- and String-valued `forceDirectDial` context entries instead of an unconditional `as String` cast.

2. **`fix: BasicHost.connect() misapplies AddrsFactory and ignores forceDirectDial`** — stop running `_addrsFactory` on the *peer's* addresses (it's for this host's own addresses only); honor `forceDirectDial` in the existing-connection short-circuit; advertise AddrsFactory-injected addresses through HolePunchService.

3. **`fix: Swarm.dialPeer ignores forceDirectDial, doesn't signal punch dials`** — same existing-connection short-circuit fix as #2, at the Swarm layer; threads a new `simultaneousConnect` flag into `Transport.dial()` so transports can tell a punch dial apart from an ordinary one (used by commit 4).

4. **`fix: UDX punch dial uses a fresh, unadvertised NAT mapping`** — when a listener is active for the target's address family *and* the dial is a `simultaneousConnect`, reuse the listener's multiplexer/socket instead of binding a fresh one, so the punch dial originates from the address already advertised to the peer. Also accepts inbound packets on port-only match (through-NAT source-IP discrepancy fallback).

`Transport.dial()` gained one new optional parameter (`bool simultaneousConnect = false`, default off). `TCPTransport` and `CircuitV2Client` accept and ignore it — they don't hole-punch. This is the only interface-level change; everything else is internal to the four files above.

## Why `simultaneousConnect` is gated, not automatic

An earlier version of this fix reused the listener's socket for *any* dial when a listener was active for that address family, not just punch dials. That's wrong: it also fires when a transport dials its *own* active listener — which real DCUtR never does (you always punch a remote peer), but `udx_transport_test.dart`'s "should establish connection between listener and dialer" does exactly that in-process, and hit an intermittent `SocketException: Can't assign requested address (errno 49)` on macOS (100% reproducible across repeated full-file runs before the fix). Scoping reuse to actual `simultaneousConnect` dials fixed it — 3 consecutive clean full-suite runs after, against a 100% reproduction rate before.

## Verification

- **Real-network hole-punch**: Dart peer ↔ go-libp2p peer, across real (non-simulated) NATs, reaching `is_direct=true` — once via CLI test harness, once on real Android hardware over cellular.
- **`dart analyze`** on all seven touched files: zero new warnings or errors vs. unpatched `fb5b924` (diffed line-by-line; the only changes are pre-existing warnings shifting line numbers).
- **`dart test`**:
  - `udx_transport_test.dart`: 10/10 passing, 3 consecutive full-file runs.
  - `swarm_integrated_test.dart`, `basic_host_addr_filter_test.dart`: no regressions vs. baseline across ~15 combined runs. One run of `basic_host_addr_filter_test.dart`'s "connect should filter addresses from AddrInfo" failed once, only when run concurrently with `swarm_integrated_test.dart` in the same invocation; did not reproduce in 9/9 isolated runs, and the same scenario was 6/6 clean on baseline. Flagging in case it's a real (if rare) interaction rather than file-level port contention — happy to dig further if you'd rather not merge with it open.
  - `basic_host_test.dart` fails to even compile on unpatched `fb5b924` (generated mocks out of sync with the `ProtoBook` interface — unrelated to this change, not touched here).

## Not included

No new tests added yet — wanted to confirm the approach (particularly the `Transport.dial()` interface change and the `simultaneousConnect` gating) before writing tests against conventions I haven't fully matched to yours. Happy to add them in this PR once you've had a look, in whatever style/location you prefer.
