### PR TITLE
fix(dcutr): add uvarint length-delimited framing to /libp2p/dcutr messages

### DIFF
--- a/lib/p2p/protocol/holepunch/holepuncher.dart
+++ b/lib/p2p/protocol/holepunch/holepuncher.dart
@@ -21,7 +21,7 @@ import '../../../core/network/notifiee.dart';
 import '../../../core/network/rcmgr.dart';
 import '../../../core/peer/addr_info.dart';
 import '../../../core/protocol/protocol.dart';
-import '../circuitv2/util/io.dart';
+import '../circuitv2/util/buffered_reader.dart';
 import '../../discovery/peer_info.dart';
 
 
@@ -265,8 +265,13 @@ class HolePuncher {
       await str.write(encodeDelimitedMessage(msg));
 
       // Wait for a CONNECT message from the remote peer
-      final reader = DelimitedReader(str, maxMsgSize);
-      final response = await reader.readMsg(HolePunch());
+      final reader = BufferedP2PStreamReader(str);
+      final responseLength = await reader.readVarint();
+      if (responseLength > maxMsgSize) {
+        throw Exception('HolePunch CONNECT response too large: $responseLength bytes');
+      }
+      final responseBytes = await reader.readExact(responseLength);
+      final response = HolePunch.fromBuffer(responseBytes);
       final rtt = DateTime.now().difference(start).inMilliseconds;
 
       if (response.type != HolePunch_Type.CONNECT) {
@@ -287,6 +292,7 @@ class HolePuncher {
       await str.write(encodeDelimitedMessage(syncMsg));
 
       return HolePunchResult(addrs, obsAddrs, rtt);
+
 
     } finally {
       str.scope().releaseMemory(maxMsgSize);

--- a/lib/p2p/protocol/holepunch/holepuncher.dart
+++ b/lib/p2p/protocol/holepunch/holepuncher.dart
@@ -21,7 +21,9 @@ import '../../../core/network/notifiee.dart';
 import '../../../core/network/rcmgr.dart';
 import '../../../core/peer/addr_info.dart';
 import '../../../core/protocol/protocol.dart';
+import '../circuitv2/util/io.dart';
 import '../../discovery/peer_info.dart';
+
 
 /// Logger for the holepuncher
 final _log = Logger('p2p-holepunch');
@@ -259,13 +261,12 @@ class HolePuncher {
         ..type = HolePunch_Type.CONNECT
         ..obsAddrs.addAll(addrsToBytes(obsAddrs));
 
-      // Serialize and write the message
-      final msgBytes = msg.writeToBuffer();
-      await str.write(Uint8List.fromList(msgBytes));
+      // Serialize and write the length-delimited message
+      await str.write(encodeDelimitedMessage(msg));
 
       // Wait for a CONNECT message from the remote peer
-      final responseBytes = await str.read();
-      final response = HolePunch.fromBuffer(responseBytes);
+      final reader = DelimitedReader(str, maxMsgSize);
+      final response = await reader.readMsg(HolePunch());
       final rtt = DateTime.now().difference(start).inMilliseconds;
 
       if (response.type != HolePunch_Type.CONNECT) {
@@ -283,10 +284,10 @@ class HolePuncher {
 
       final syncMsg = HolePunch()..type = HolePunch_Type.SYNC;
       // Serialize and write the sync message
-      final syncMsgBytes = syncMsg.writeToBuffer();
-      await str.write(Uint8List.fromList(syncMsgBytes));
+      await str.write(encodeDelimitedMessage(syncMsg));
 
       return HolePunchResult(addrs, obsAddrs, rtt);
+
     } finally {
       str.scope().releaseMemory(maxMsgSize);
     }

--- a/lib/p2p/protocol/holepunch/holepuncher.dart
+++ b/lib/p2p/protocol/holepunch/holepuncher.dart
@@ -1,8 +1,6 @@
 /// The holepuncher implementation for the holepunch protocol.
 
 import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/pb/holepunch.pb.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/util.dart';

--- a/lib/p2p/protocol/holepunch/service.dart
+++ b/lib/p2p/protocol/holepunch/service.dart
@@ -17,7 +17,7 @@ import 'package:synchronized/synchronized.dart';
 import '../../../core/network/context.dart';
 import '../../../core/network/rcmgr.dart';
 import '../../../core/network/stream.dart'; // For P2PStream
-import '../circuitv2/util/io.dart';
+import '../circuitv2/util/buffered_reader.dart';
 import '../../../core/network/common.dart' show Direction; // Import Direction
 import '../../../core/peer/addr_info.dart';
 import '../../discovery/peer_info.dart';
@@ -214,10 +214,15 @@ class HolePunchServiceImpl implements HolePunchService {
     await str.scope().reserveMemory(maxMsgSize, ReservationPriority.always);
     try {
       str.setDeadline(DateTime.now().add(streamTimeout));
-      final reader = DelimitedReader(str, maxMsgSize);
+      final reader = BufferedP2PStreamReader(str);
 
       // Read Connect message
-      final msg = await reader.readMsg(HolePunch());
+      final msgLength = await reader.readVarint();
+      if (msgLength > maxMsgSize) {
+        throw Exception('HolePunch CONNECT message too large: $msgLength bytes');
+      }
+      final msgBytes = await reader.readExact(msgLength);
+      final msg = HolePunch.fromBuffer(msgBytes);
       if (msg.type != HolePunch_Type.CONNECT) {
         throw Exception('Expected CONNECT message from initiator but got ${msg.type}');
       }
@@ -241,7 +246,12 @@ class HolePunchServiceImpl implements HolePunchService {
       await str.write(encodeDelimitedMessage(response));
 
       // Read SYNC message
-      final syncMsg = await reader.readMsg(HolePunch());
+      final syncLength = await reader.readVarint();
+      if (syncLength > maxMsgSize) {
+        throw Exception('HolePunch SYNC message too large: $syncLength bytes');
+      }
+      final syncBytes = await reader.readExact(syncLength);
+      final syncMsg = HolePunch.fromBuffer(syncBytes);
       if (syncMsg.type != HolePunch_Type.SYNC) {
         throw Exception('Expected SYNC message from initiator but got ${syncMsg.type}');
       }
@@ -251,6 +261,7 @@ class HolePunchServiceImpl implements HolePunchService {
         obsDial,
         ownAddrs,
       );
+
 
     } finally {
       str.scope().releaseMemory(maxMsgSize);

--- a/lib/p2p/protocol/holepunch/service.dart
+++ b/lib/p2p/protocol/holepunch/service.dart
@@ -1,8 +1,6 @@
 /// Implementation of the holepunch service.
 
 import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/holepunch_service.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/holepuncher.dart';

--- a/lib/p2p/protocol/holepunch/service.dart
+++ b/lib/p2p/protocol/holepunch/service.dart
@@ -17,6 +17,7 @@ import 'package:synchronized/synchronized.dart';
 import '../../../core/network/context.dart';
 import '../../../core/network/rcmgr.dart';
 import '../../../core/network/stream.dart'; // For P2PStream
+import '../circuitv2/util/io.dart';
 import '../../../core/network/common.dart' show Direction; // Import Direction
 import '../../../core/peer/addr_info.dart';
 import '../../discovery/peer_info.dart';
@@ -213,10 +214,10 @@ class HolePunchServiceImpl implements HolePunchService {
     await str.scope().reserveMemory(maxMsgSize, ReservationPriority.always);
     try {
       str.setDeadline(DateTime.now().add(streamTimeout));
+      final reader = DelimitedReader(str, maxMsgSize);
 
       // Read Connect message
-      final msgBytes = await str.read();
-      final msg = HolePunch.fromBuffer(msgBytes);
+      final msg = await reader.readMsg(HolePunch());
       if (msg.type != HolePunch_Type.CONNECT) {
         throw Exception('Expected CONNECT message from initiator but got ${msg.type}');
       }
@@ -237,12 +238,10 @@ class HolePunchServiceImpl implements HolePunchService {
         ..obsAddrs.addAll(addrsToBytes(ownAddrs));
 
       final tstart = DateTime.now();
-      final responseBytes = response.writeToBuffer();
-      await str.write(Uint8List.fromList(responseBytes));
+      await str.write(encodeDelimitedMessage(response));
 
       // Read SYNC message
-      final syncMsgBytes = await str.read();
-      final syncMsg = HolePunch.fromBuffer(syncMsgBytes);
+      final syncMsg = await reader.readMsg(HolePunch());
       if (syncMsg.type != HolePunch_Type.SYNC) {
         throw Exception('Expected SYNC message from initiator but got ${syncMsg.type}');
       }
@@ -252,6 +251,7 @@ class HolePunchServiceImpl implements HolePunchService {
         obsDial,
         ownAddrs,
       );
+
     } finally {
       str.scope().releaseMemory(maxMsgSize);
     }

--- a/lib/p2p/protocol/holepunch/util.dart
+++ b/lib/p2p/protocol/holepunch/util.dart
@@ -6,6 +6,8 @@ import 'package:dart_libp2p/core/host/host.dart';
 import 'package:dart_libp2p/core/multiaddr.dart';
 import 'package:dart_libp2p/core/network/conn.dart';
 import 'package:dart_libp2p/core/peer/peer_id.dart';
+import 'package:dart_libp2p/p2p/multiaddr/codec.dart';
+
 
 
 /// Protocol ID for the holepunch protocol
@@ -66,3 +68,14 @@ Conn? getDirectConnection(Host host, PeerId peerId) {
   }
   return null;
 }
+
+/// Encodes a protocol buffer message with a varint length prefix for go-libp2p pbio compatibility.
+Uint8List encodeDelimitedMessage(dynamic message) {
+  final messageBytes = (message as dynamic).writeToBuffer() as List<int>;
+  final lengthBytes = MultiAddrCodec.encodeVarint(messageBytes.length);
+  final result = Uint8List(lengthBytes.length + messageBytes.length);
+  result.setAll(0, lengthBytes);
+  result.setAll(lengthBytes.length, messageBytes);
+  return result;
+}
+

--- a/lib/p2p/protocol/holepunch/util.dart
+++ b/lib/p2p/protocol/holepunch/util.dart
@@ -7,6 +7,7 @@ import 'package:dart_libp2p/core/multiaddr.dart';
 import 'package:dart_libp2p/core/network/conn.dart';
 import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/p2p/multiaddr/codec.dart';
+import 'package:protobuf/protobuf.dart';
 
 
 
@@ -70,12 +71,11 @@ Conn? getDirectConnection(Host host, PeerId peerId) {
 }
 
 /// Encodes a protocol buffer message with a varint length prefix for go-libp2p pbio compatibility.
-Uint8List encodeDelimitedMessage(dynamic message) {
-  final messageBytes = (message as dynamic).writeToBuffer() as List<int>;
+Uint8List encodeDelimitedMessage(GeneratedMessage message) {
+  final messageBytes = message.writeToBuffer();
   final lengthBytes = MultiAddrCodec.encodeVarint(messageBytes.length);
   final result = Uint8List(lengthBytes.length + messageBytes.length);
   result.setAll(0, lengthBytes);
   result.setAll(lengthBytes.length, messageBytes);
   return result;
 }
-

--- a/test/protocol/holepunch/holepunch_util_test.dart
+++ b/test/protocol/holepunch/holepunch_util_test.dart
@@ -5,12 +5,15 @@ import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/core/host/host.dart';
 import 'package:dart_libp2p/core/network/network.dart';
 import 'package:dart_libp2p/core/network/conn.dart';
+import 'package:dart_libp2p/core/network/stream.dart';
+import 'package:dart_libp2p/p2p/protocol/circuitv2/util/buffered_reader.dart';
+import 'package:dart_libp2p/p2p/protocol/holepunch/pb/holepunch.pb.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/util.dart';
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
 
-@GenerateMocks([Host, Network, Conn])
+@GenerateMocks([Host, Network, Conn, P2PStream])
 import 'holepunch_util_test.mocks.dart';
 
 void main() {
@@ -34,9 +37,10 @@ void main() {
 
     group('Relay Address Detection', () {
       test('should detect relay addresses correctly', () {
-        final relayAddr = MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay/p2p-circuit');
+        final relayAddr =
+            MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay/p2p-circuit');
         final directAddr = MultiAddr('/ip4/127.0.0.1/tcp/4001');
-        
+
         expect(isRelayAddress(relayAddr), isTrue);
         expect(isRelayAddress(directAddr), isFalse);
       });
@@ -53,17 +57,20 @@ void main() {
           MultiAddr('/ip4/127.0.0.1/tcp/4001'), // direct
           MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay/p2p-circuit'), // relay
           MultiAddr('/ip6/::1/tcp/4003'), // direct
-          MultiAddr('/ip4/192.168.1.100/tcp/4004/p2p/QmRelay2/p2p-circuit'), // relay
+          MultiAddr(
+              '/ip4/192.168.1.100/tcp/4004/p2p/QmRelay2/p2p-circuit'), // relay
         ];
 
         final filteredAddresses = removeRelayAddrs(addresses);
-        
+
         expect(filteredAddresses, hasLength(2));
-        expect(filteredAddresses[0].toString(), contains('/ip4/127.0.0.1/tcp/4001'));
+        expect(filteredAddresses[0].toString(),
+            contains('/ip4/127.0.0.1/tcp/4001'));
         expect(filteredAddresses[1].toString(), contains('/ip6/::1/tcp/4003'));
       });
 
-      test('should return empty list when all addresses are relay addresses', () {
+      test('should return empty list when all addresses are relay addresses',
+          () {
         final addresses = [
           MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay1/p2p-circuit'),
           MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay2/p2p-circuit'),
@@ -112,7 +119,9 @@ void main() {
       test('should skip invalid bytes during deserialization', () {
         final validAddr = MultiAddr('/ip4/127.0.0.1/tcp/4001');
         final validBytes = [validAddr.toBytes()];
-        final invalidBytes = [Uint8List.fromList([1, 2, 3])]; // Invalid multiaddr bytes
+        final invalidBytes = [
+          Uint8List.fromList([1, 2, 3])
+        ]; // Invalid multiaddr bytes
 
         final mixedBytes = [...validBytes, ...invalidBytes];
         final reconverted = addrsFromBytes(mixedBytes);
@@ -125,17 +134,74 @@ void main() {
       test('should handle different input types for bytes', () {
         final addr = MultiAddr('/ip4/127.0.0.1/tcp/4001');
         final addrBytes = addr.toBytes();
-        
+
         // Test with Uint8List
         final fromUint8List = addrsFromBytes([addrBytes]);
         expect(fromUint8List, hasLength(1));
-        
+
         // Test with List<int>
         final fromListInt = addrsFromBytes([addrBytes.toList()]);
         expect(fromListInt, hasLength(1));
-        
+
         // Both should produce same result
         expect(fromUint8List[0].toString(), equals(fromListInt[0].toString()));
+      });
+    });
+
+    group('Delimited Message Encoding & Varint Framing', () {
+      test('prepends the protobuf payload length as a uvarint', () {
+        final message = HolePunch()
+          ..type = HolePunch_Type.CONNECT
+          ..obsAddrs.add(Uint8List.fromList([1, 2, 3, 4]));
+        final payload = message.writeToBuffer();
+
+        final encoded = encodeDelimitedMessage(message);
+        final prefix = _decodeUvarint(encoded);
+
+        expect(prefix.value, payload.length);
+        expect(encoded.sublist(prefix.byteLength), payload);
+      });
+
+      test('uses a multi-byte uvarint for payloads larger than 127 bytes', () {
+        final message = HolePunch()
+          ..type = HolePunch_Type.CONNECT
+          ..obsAddrs.add(Uint8List(256));
+        final payload = message.writeToBuffer();
+
+        final encoded = encodeDelimitedMessage(message);
+        final prefix = _decodeUvarint(encoded);
+
+        expect(payload.length, greaterThan(127));
+        expect(prefix.byteLength, greaterThan(1));
+        expect(prefix.value, payload.length);
+        expect(encoded.sublist(prefix.byteLength), payload);
+      });
+
+      test('buffered reader reads a fragmented delimited message', () async {
+        final message = HolePunch()
+          ..type = HolePunch_Type.CONNECT
+          ..obsAddrs.add(Uint8List(256));
+        final encoded = encodeDelimitedMessage(message);
+        final chunks = <Uint8List>[
+          Uint8List.fromList(encoded.sublist(0, 1)),
+          Uint8List.fromList(encoded.sublist(1, 17)),
+          Uint8List.fromList(encoded.sublist(17)),
+        ];
+        var nextChunk = 0;
+        final stream = MockP2PStream();
+        when(stream.read()).thenAnswer(
+          (_) async =>
+              nextChunk < chunks.length ? chunks[nextChunk++] : Uint8List(0),
+        );
+
+        final reader = BufferedP2PStreamReader(stream);
+        final payloadLength = await reader.readVarint();
+        final payload = await reader.readExact(payloadLength);
+        final decoded = HolePunch.fromBuffer(payload);
+
+        expect(payloadLength, message.writeToBuffer().length);
+        expect(decoded.type, HolePunch_Type.CONNECT);
+        expect(decoded.obsAddrs.single, Uint8List(256));
       });
     });
 
@@ -148,43 +214,46 @@ void main() {
         mockHost = MockHost();
         mockNetwork = MockNetwork();
         testPeerId = await PeerId.random();
-        
+
         when(mockHost.network).thenReturn(mockNetwork);
       });
 
       test('should return direct connection when available', () {
         final mockDirectConn = MockConn();
         final mockRelayConn = MockConn();
-        
+
         final directAddr = MultiAddr('/ip4/127.0.0.1/tcp/4001');
-        final relayAddr = MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay/p2p-circuit');
-        
+        final relayAddr =
+            MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay/p2p-circuit');
+
         when(mockDirectConn.remoteMultiaddr).thenReturn(directAddr);
         when(mockRelayConn.remoteMultiaddr).thenReturn(relayAddr);
-        
+
         when(mockNetwork.connsToPeer(testPeerId))
             .thenReturn([mockRelayConn, mockDirectConn]);
 
         final directConn = getDirectConnection(mockHost, testPeerId);
-        
+
         expect(directConn, equals(mockDirectConn));
       });
 
       test('should return null when only relay connections exist', () {
         final mockRelayConn1 = MockConn();
         final mockRelayConn2 = MockConn();
-        
-        final relayAddr1 = MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay1/p2p-circuit');
-        final relayAddr2 = MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay2/p2p-circuit');
-        
+
+        final relayAddr1 =
+            MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay1/p2p-circuit');
+        final relayAddr2 =
+            MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay2/p2p-circuit');
+
         when(mockRelayConn1.remoteMultiaddr).thenReturn(relayAddr1);
         when(mockRelayConn2.remoteMultiaddr).thenReturn(relayAddr2);
-        
+
         when(mockNetwork.connsToPeer(testPeerId))
             .thenReturn([mockRelayConn1, mockRelayConn2]);
 
         final directConn = getDirectConnection(mockHost, testPeerId);
-        
+
         expect(directConn, isNull);
       });
 
@@ -192,27 +261,41 @@ void main() {
         when(mockNetwork.connsToPeer(testPeerId)).thenReturn([]);
 
         final directConn = getDirectConnection(mockHost, testPeerId);
-        
+
         expect(directConn, isNull);
       });
 
       test('should return first direct connection when multiple exist', () {
         final mockDirectConn1 = MockConn();
         final mockDirectConn2 = MockConn();
-        
+
         final directAddr1 = MultiAddr('/ip4/127.0.0.1/tcp/4001');
         final directAddr2 = MultiAddr('/ip4/127.0.0.1/tcp/4002');
-        
+
         when(mockDirectConn1.remoteMultiaddr).thenReturn(directAddr1);
         when(mockDirectConn2.remoteMultiaddr).thenReturn(directAddr2);
-        
+
         when(mockNetwork.connsToPeer(testPeerId))
             .thenReturn([mockDirectConn1, mockDirectConn2]);
 
         final directConn = getDirectConnection(mockHost, testPeerId);
-        
+
         expect(directConn, equals(mockDirectConn1));
       });
     });
   });
+}
+
+({int value, int byteLength}) _decodeUvarint(Uint8List bytes) {
+  var value = 0;
+  var shift = 0;
+  for (var index = 0; index < bytes.length; index++) {
+    final byte = bytes[index];
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) == 0) {
+      return (value: value, byteLength: index + 1);
+    }
+    shift += 7;
+  }
+  throw StateError('unterminated uvarint');
 }

--- a/test/protocol/holepunch/holepunch_util_test.mocks.dart
+++ b/test/protocol/holepunch/holepunch_util_test.mocks.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i13;
+import 'dart:typed_data' as _i19;
 
 import 'package:dart_libp2p/core/connmgr/conn_manager.dart' as _i6;
 import 'package:dart_libp2p/core/crypto/keys.dart' as _i18;
@@ -161,6 +162,27 @@ class _FakeConnStats_11 extends _i1.SmartFake implements _i10.ConnStats {
 
 class _FakeConnScope_12 extends _i1.SmartFake implements _i9.ConnScope {
   _FakeConnScope_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStreamStats_13 extends _i1.SmartFake implements _i8.StreamStats {
+  _FakeStreamStats_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStreamManagementScope_14 extends _i1.SmartFake
+    implements _i9.StreamManagementScope {
+  _FakeStreamManagementScope_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -693,4 +715,202 @@ class MockConn extends _i1.Mock implements _i10.Conn {
           ),
         )),
       ) as _i13.Future<_i8.P2PStream<dynamic>>);
+}
+
+/// A class which mocks [P2PStream].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockP2PStream<T> extends _i1.Mock implements _i8.P2PStream<T> {
+  MockP2PStream() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i10.Conn get conn => (super.noSuchMethod(
+        Invocation.getter(#conn),
+        returnValue: _FakeConn_8(
+          this,
+          Invocation.getter(#conn),
+        ),
+      ) as _i10.Conn);
+
+  @override
+  _i8.P2PStream<_i19.Uint8List> get incoming => (super.noSuchMethod(
+        Invocation.getter(#incoming),
+        returnValue: _FakeP2PStream_6<_i19.Uint8List>(
+          this,
+          Invocation.getter(#incoming),
+        ),
+      ) as _i8.P2PStream<_i19.Uint8List>);
+
+  @override
+  bool get isClosed => (super.noSuchMethod(
+        Invocation.getter(#isClosed),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get isWritable => (super.noSuchMethod(
+        Invocation.getter(#isWritable),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  String id() => (super.noSuchMethod(
+        Invocation.method(
+          #id,
+          [],
+        ),
+        returnValue: _i17.dummyValue<String>(
+          this,
+          Invocation.method(
+            #id,
+            [],
+          ),
+        ),
+      ) as String);
+
+  @override
+  String protocol() => (super.noSuchMethod(
+        Invocation.method(
+          #protocol,
+          [],
+        ),
+        returnValue: _i17.dummyValue<String>(
+          this,
+          Invocation.method(
+            #protocol,
+            [],
+          ),
+        ),
+      ) as String);
+
+  @override
+  _i13.Future<void> setProtocol(String? id) => (super.noSuchMethod(
+        Invocation.method(
+          #setProtocol,
+          [id],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i8.StreamStats stat() => (super.noSuchMethod(
+        Invocation.method(
+          #stat,
+          [],
+        ),
+        returnValue: _FakeStreamStats_13(
+          this,
+          Invocation.method(
+            #stat,
+            [],
+          ),
+        ),
+      ) as _i8.StreamStats);
+
+  @override
+  _i9.StreamManagementScope scope() => (super.noSuchMethod(
+        Invocation.method(
+          #scope,
+          [],
+        ),
+        returnValue: _FakeStreamManagementScope_14(
+          this,
+          Invocation.method(
+            #scope,
+            [],
+          ),
+        ),
+      ) as _i9.StreamManagementScope);
+
+  @override
+  _i13.Future<_i19.Uint8List> read([int? maxLength]) => (super.noSuchMethod(
+        Invocation.method(
+          #read,
+          [maxLength],
+        ),
+        returnValue: _i13.Future<_i19.Uint8List>.value(_i19.Uint8List(0)),
+      ) as _i13.Future<_i19.Uint8List>);
+
+  @override
+  _i13.Future<void> write(_i19.Uint8List? data) => (super.noSuchMethod(
+        Invocation.method(
+          #write,
+          [data],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> closeWrite() => (super.noSuchMethod(
+        Invocation.method(
+          #closeWrite,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> closeRead() => (super.noSuchMethod(
+        Invocation.method(
+          #closeRead,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> reset() => (super.noSuchMethod(
+        Invocation.method(
+          #reset,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> setDeadline(DateTime? time) => (super.noSuchMethod(
+        Invocation.method(
+          #setDeadline,
+          [time],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> setReadDeadline(DateTime? time) => (super.noSuchMethod(
+        Invocation.method(
+          #setReadDeadline,
+          [time],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> setWriteDeadline(DateTime? time) => (super.noSuchMethod(
+        Invocation.method(
+          #setWriteDeadline,
+          [time],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }


### PR DESCRIPTION
Closes #17.

## Summary

- prepend unsigned-varint lengths to outbound DCUtR `CONNECT` and `SYNC` protobuf messages
- read inbound messages as a uvarint length followed by the exact protobuf payload
- enforce the existing 4 KiB message limit before reading payloads
- add coverage for single-byte and multi-byte prefixes and fragmented stream reads

This makes the Dart DCUtR implementation compatible with the `pbio` framing used by go-libp2p.

## Verification

- `dart test test/protocol/holepunch/holepunch_util_test.dart` (19 passed)
- `dart test test/protocol/holepunch/` (71 passed)

Tests used a temporary dependency override to published `dart_udx: ^2.0.3`, because upstream `main` currently points to a missing sibling path dependency (`../dart-udx`). The override is not included in this PR.
