### PR TITLE
fix(dcutr): make simultaneous connect interoperable and advertise dialable addresses

### DIFF
--- a/lib/core/network/context.dart
+++ b/lib/core/network/context.dart
@@ -47,9 +47,14 @@ class Context {
 
   /// Gets the force direct dial option from the Context
   (bool, String) getForceDirectDial() {
+    // Callers store this key as either a bool (e.g. holepunch/service.dart's
+    // `true`) or a String reason (e.g. holepuncher.dart). The unconditional
+    // `as String` cast below threw a TypeError for bool-valued callers,
+    // silently discarding the force-direct-dial signal on that path. Accept
+    // either representation.
     final value = getValue(_forceDirectDialKey);
     if (value != null) {
-      return (true, value as String);
+      return (true, value is String ? value : value.toString());
     }
     return (false, '');
   }

--- a/lib/p2p/host/basic/basic_host.dart
+++ b/lib/p2p/host/basic/basic_host.dart
@@ -103,6 +103,15 @@ List<MultiAddr> defaultAddrsFactory(List<MultiAddr> addrs) {
   }).toList();
 }
 
+/// Whether two IP multiaddrs belong to the same address family.
+///
+/// Used when expanding an unspecified listener onto concrete interfaces: an
+/// IPv4-bound socket must never be advertised with an IPv6 interface address,
+/// or vice versa.
+bool addressesShareIPFamily(MultiAddr first, MultiAddr second) =>
+    (first.hasProtocol('ip4') && second.hasProtocol('ip4')) ||
+    (first.hasProtocol('ip6') && second.hasProtocol('ip6'));
+
 // Removed AddrsFactory typedef as it's now imported
 
 // Removed MockProtocolSwitch class definition
@@ -860,6 +869,9 @@ class BasicHost implements Host {
           if (_filteredInterfaceAddrs.isNotEmpty) {
             for (final interfaceAddr in _filteredInterfaceAddrs) {
               // interfaceAddr is a bare IP MultiAddr, e.g., /ip4/192.168.10.118
+              // Never attach an IPv4 listener's transport suffix to an IPv6
+              // interface (or vice versa): no socket is listening there.
+              if (!addressesShareIPFamily(listenAddr, interfaceAddr)) continue;
               try {
                 // Combine the interface address string with the suffix string
                 final combinedAddrString = interfaceAddr.toString() + suffixString;

--- a/lib/p2p/host/basic/basic_host.dart
+++ b/lib/p2p/host/basic/basic_host.dart
@@ -379,7 +379,13 @@ class BasicHost implements Host {
       _holePunchService = holepunch_impl.HolePunchServiceImpl(
         this,
         _idService, // Pass the existing IDService instance
-        () => publicAddrs, // Pass a function that returns only public/observed addrs
+        // `publicAddrs` only reflects observed/AutoNAT-confirmed addresses,
+        // so it misses addresses injected via the host's AddrsFactory (e.g.
+        // an operator-supplied external address on a host AutoNAT can't
+        // observe directly). Use `addrs` (which already runs AddrsFactory)
+        // minus relay addresses instead, so HolePunchService advertises
+        // those addresses too.
+        () => addrs.where((a) => !isRelayAddress(a)).toList(),
         options: const holepunch_impl.HolePunchOptions(), // Default options for now
       );
       await _holePunchService!.start(); // Call start as per its interface
@@ -1045,7 +1051,16 @@ class BasicHost implements Host {
 
     final filterStartTime = DateTime.now();
     
-    final filteredAddrs = _addrsFactory(pi.addrs);
+    // _addrsFactory transforms how THIS host presents its OWN addresses to
+    // others (see `get addrs => _addrsFactory(allAddrs)` above) — it must
+    // never run on `pi.addrs`, the addresses of the PEER being connected to.
+    // The original code called it here anyway, so every connect() to any
+    // peer (relay, hole-punch target, anyone) appended this host's own
+    // AddrsFactory-derived addresses into THAT PEER's peerstore entry.
+    // Swarm.dialPeer then raced this host's own address as a bogus dial
+    // candidate for every subsequent dial to that peer — observed as a host
+    // attempting to dial its own external address.
+    final filteredAddrs = pi.addrs;
 
     
     await peerStore.addrBook.addAddrs(pi.id, filteredAddrs, Duration(minutes: 5));
@@ -1057,8 +1072,15 @@ class BasicHost implements Host {
 
     final connectedness = _network.connectedness(pi.id);
 
-    
-    if (connectedness == Connectedness.connected) {
+    // This early return fires even for a *relay* connection
+    // (Connectedness.limited-worthy, but connectedness() doesn't distinguish
+    // it from a full connection here) — meaning DCUtR's forceDirectDial punch
+    // dial never even reached Swarm.dialPeer (where its own forceDirectDial
+    // check applies). ForceDirectDial's entire purpose is "dial anyway, even
+    // though a connection exists" — honor that here, one layer up from where
+    // it was already checked.
+    final skipEarlyReturn = context?.getForceDirectDial().$1 ?? false;
+    if (connectedness == Connectedness.connected && !skipEarlyReturn) {
       final totalTime = DateTime.now().difference(startTime);
 
       return;

--- a/lib/p2p/network/swarm/swarm.dart
+++ b/lib/p2p/network/swarm/swarm.dart
@@ -786,11 +786,24 @@ class Swarm implements Network {
         }
       }
       
-      if (healthyConns.isNotEmpty) {
+      // forceDirectDial is set by holepunch/service.dart and holepuncher.dart
+      // on every punch dial, but nothing in this function previously read it
+      // — DCUtR's entire precondition is an existing RELAY connection, so
+      // dialPeer always returned that relay connection here and the punch
+      // dial below (which would actually reach the transport) never ran.
+      // Only skip the short-circuit when every existing healthy connection
+      // is relayed; an already-direct connection is left alone.
+      final forceDirectDial = context.getForceDirectDial().$1;
+      final onlyRelayed = healthyConns.isNotEmpty &&
+          healthyConns.every((c) => c.remoteMultiaddr.hasProtocol('p2p-circuit'));
+
+      if (healthyConns.isNotEmpty && !(forceDirectDial && onlyRelayed)) {
         // Prefer newest connection - more likely to be alive for relayed paths
         // where the end-to-end path can break without local detection
         _logger.warning('Swarm.dialPeer: Found healthy connection for peer ${peerId.toString()}. Returning newest connection ID: ${healthyConns.last.id}');
         return healthyConns.last;
+      } else if (healthyConns.isNotEmpty) {
+        _logger.fine('Swarm.dialPeer: forceDirectDial set and only relayed connection(s) exist for ${peerId.toString()} — dialing fresh addresses instead of reusing the relay connection.');
       } else {
         _logger.warning('Swarm.dialPeer: No healthy connections found for peer ${peerId.toString()}. Will create new connection.');
       }
@@ -1005,8 +1018,13 @@ class Swarm implements Network {
       }
     }
 
-    // Dial the address
-    final transportConn = await transport.dial(dialAddr);
+    // Dial the address. forceDirectDial marks a DCUtR punch attempt, which
+    // hole-punch-capable transports (e.g. UDX) use to dial from the same
+    // socket whose NAT mapping was already advertised to the peer.
+    final transportConn = await transport.dial(
+      dialAddr,
+      simultaneousConnect: context.getForceDirectDial().$1,
+    );
     
     // Upgrade the connection
     final upgradedConn = await _upgrader.upgradeOutbound(

--- a/lib/p2p/protocol/circuitv2/client/client.dart
+++ b/lib/p2p/protocol/circuitv2/client/client.dart
@@ -295,7 +295,7 @@ class CircuitV2Client implements Transport {
 
 
   @override
-  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout}) async {
+  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout, bool simultaneousConnect = false}) async {
     _log.info('[CircuitV2Client.dial] 🔌 Starting circuit dial to $addr');
     
     // 1. Parse the /p2p-circuit address.

--- a/lib/p2p/protocol/holepunch/holepuncher.dart
+++ b/lib/p2p/protocol/holepunch/holepuncher.dart
@@ -21,7 +21,7 @@ import '../../../core/network/notifiee.dart';
 import '../../../core/network/rcmgr.dart';
 import '../../../core/peer/addr_info.dart';
 import '../../../core/protocol/protocol.dart';
-import '../circuitv2/util/io.dart';
+import '../circuitv2/util/buffered_reader.dart';
 import '../../discovery/peer_info.dart';
 
 
@@ -265,8 +265,13 @@ class HolePuncher {
       await str.write(encodeDelimitedMessage(msg));
 
       // Wait for a CONNECT message from the remote peer
-      final reader = DelimitedReader(str, maxMsgSize);
-      final response = await reader.readMsg(HolePunch());
+      final reader = BufferedP2PStreamReader(str);
+      final responseLength = await reader.readVarint();
+      if (responseLength > maxMsgSize) {
+        throw Exception('HolePunch CONNECT response too large: $responseLength bytes');
+      }
+      final responseBytes = await reader.readExact(responseLength);
+      final response = HolePunch.fromBuffer(responseBytes);
       final rtt = DateTime.now().difference(start).inMilliseconds;
 
       if (response.type != HolePunch_Type.CONNECT) {
@@ -287,6 +292,7 @@ class HolePuncher {
       await str.write(encodeDelimitedMessage(syncMsg));
 
       return HolePunchResult(addrs, obsAddrs, rtt);
+
 
     } finally {
       str.scope().releaseMemory(maxMsgSize);

--- a/lib/p2p/protocol/holepunch/holepuncher.dart
+++ b/lib/p2p/protocol/holepunch/holepuncher.dart
@@ -21,7 +21,9 @@ import '../../../core/network/notifiee.dart';
 import '../../../core/network/rcmgr.dart';
 import '../../../core/peer/addr_info.dart';
 import '../../../core/protocol/protocol.dart';
+import '../circuitv2/util/io.dart';
 import '../../discovery/peer_info.dart';
+
 
 /// Logger for the holepuncher
 final _log = Logger('p2p-holepunch');
@@ -259,13 +261,12 @@ class HolePuncher {
         ..type = HolePunch_Type.CONNECT
         ..obsAddrs.addAll(addrsToBytes(obsAddrs));
 
-      // Serialize and write the message
-      final msgBytes = msg.writeToBuffer();
-      await str.write(Uint8List.fromList(msgBytes));
+      // Serialize and write the length-delimited message
+      await str.write(encodeDelimitedMessage(msg));
 
       // Wait for a CONNECT message from the remote peer
-      final responseBytes = await str.read();
-      final response = HolePunch.fromBuffer(responseBytes);
+      final reader = DelimitedReader(str, maxMsgSize);
+      final response = await reader.readMsg(HolePunch());
       final rtt = DateTime.now().difference(start).inMilliseconds;
 
       if (response.type != HolePunch_Type.CONNECT) {
@@ -283,10 +284,10 @@ class HolePuncher {
 
       final syncMsg = HolePunch()..type = HolePunch_Type.SYNC;
       // Serialize and write the sync message
-      final syncMsgBytes = syncMsg.writeToBuffer();
-      await str.write(Uint8List.fromList(syncMsgBytes));
+      await str.write(encodeDelimitedMessage(syncMsg));
 
       return HolePunchResult(addrs, obsAddrs, rtt);
+
     } finally {
       str.scope().releaseMemory(maxMsgSize);
     }

--- a/lib/p2p/protocol/holepunch/holepuncher.dart
+++ b/lib/p2p/protocol/holepunch/holepuncher.dart
@@ -1,8 +1,6 @@
 /// The holepuncher implementation for the holepunch protocol.
 
 import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/pb/holepunch.pb.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/util.dart';

--- a/lib/p2p/protocol/holepunch/service.dart
+++ b/lib/p2p/protocol/holepunch/service.dart
@@ -17,7 +17,7 @@ import 'package:synchronized/synchronized.dart';
 import '../../../core/network/context.dart';
 import '../../../core/network/rcmgr.dart';
 import '../../../core/network/stream.dart'; // For P2PStream
-import '../circuitv2/util/io.dart';
+import '../circuitv2/util/buffered_reader.dart';
 import '../../../core/network/common.dart' show Direction; // Import Direction
 import '../../../core/peer/addr_info.dart';
 import '../../discovery/peer_info.dart';
@@ -214,10 +214,15 @@ class HolePunchServiceImpl implements HolePunchService {
     await str.scope().reserveMemory(maxMsgSize, ReservationPriority.always);
     try {
       str.setDeadline(DateTime.now().add(streamTimeout));
-      final reader = DelimitedReader(str, maxMsgSize);
+      final reader = BufferedP2PStreamReader(str);
 
       // Read Connect message
-      final msg = await reader.readMsg(HolePunch());
+      final msgLength = await reader.readVarint();
+      if (msgLength > maxMsgSize) {
+        throw Exception('HolePunch CONNECT message too large: $msgLength bytes');
+      }
+      final msgBytes = await reader.readExact(msgLength);
+      final msg = HolePunch.fromBuffer(msgBytes);
       if (msg.type != HolePunch_Type.CONNECT) {
         throw Exception('Expected CONNECT message from initiator but got ${msg.type}');
       }
@@ -241,7 +246,12 @@ class HolePunchServiceImpl implements HolePunchService {
       await str.write(encodeDelimitedMessage(response));
 
       // Read SYNC message
-      final syncMsg = await reader.readMsg(HolePunch());
+      final syncLength = await reader.readVarint();
+      if (syncLength > maxMsgSize) {
+        throw Exception('HolePunch SYNC message too large: $syncLength bytes');
+      }
+      final syncBytes = await reader.readExact(syncLength);
+      final syncMsg = HolePunch.fromBuffer(syncBytes);
       if (syncMsg.type != HolePunch_Type.SYNC) {
         throw Exception('Expected SYNC message from initiator but got ${syncMsg.type}');
       }
@@ -251,6 +261,7 @@ class HolePunchServiceImpl implements HolePunchService {
         obsDial,
         ownAddrs,
       );
+
 
     } finally {
       str.scope().releaseMemory(maxMsgSize);

--- a/lib/p2p/protocol/holepunch/service.dart
+++ b/lib/p2p/protocol/holepunch/service.dart
@@ -1,8 +1,6 @@
 /// Implementation of the holepunch service.
 
 import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/holepunch_service.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/holepuncher.dart';

--- a/lib/p2p/protocol/holepunch/service.dart
+++ b/lib/p2p/protocol/holepunch/service.dart
@@ -17,6 +17,7 @@ import 'package:synchronized/synchronized.dart';
 import '../../../core/network/context.dart';
 import '../../../core/network/rcmgr.dart';
 import '../../../core/network/stream.dart'; // For P2PStream
+import '../circuitv2/util/io.dart';
 import '../../../core/network/common.dart' show Direction; // Import Direction
 import '../../../core/peer/addr_info.dart';
 import '../../discovery/peer_info.dart';
@@ -213,10 +214,10 @@ class HolePunchServiceImpl implements HolePunchService {
     await str.scope().reserveMemory(maxMsgSize, ReservationPriority.always);
     try {
       str.setDeadline(DateTime.now().add(streamTimeout));
+      final reader = DelimitedReader(str, maxMsgSize);
 
       // Read Connect message
-      final msgBytes = await str.read();
-      final msg = HolePunch.fromBuffer(msgBytes);
+      final msg = await reader.readMsg(HolePunch());
       if (msg.type != HolePunch_Type.CONNECT) {
         throw Exception('Expected CONNECT message from initiator but got ${msg.type}');
       }
@@ -237,12 +238,10 @@ class HolePunchServiceImpl implements HolePunchService {
         ..obsAddrs.addAll(addrsToBytes(ownAddrs));
 
       final tstart = DateTime.now();
-      final responseBytes = response.writeToBuffer();
-      await str.write(Uint8List.fromList(responseBytes));
+      await str.write(encodeDelimitedMessage(response));
 
       // Read SYNC message
-      final syncMsgBytes = await str.read();
-      final syncMsg = HolePunch.fromBuffer(syncMsgBytes);
+      final syncMsg = await reader.readMsg(HolePunch());
       if (syncMsg.type != HolePunch_Type.SYNC) {
         throw Exception('Expected SYNC message from initiator but got ${syncMsg.type}');
       }
@@ -252,6 +251,7 @@ class HolePunchServiceImpl implements HolePunchService {
         obsDial,
         ownAddrs,
       );
+
     } finally {
       str.scope().releaseMemory(maxMsgSize);
     }

--- a/lib/p2p/protocol/holepunch/util.dart
+++ b/lib/p2p/protocol/holepunch/util.dart
@@ -6,6 +6,8 @@ import 'package:dart_libp2p/core/host/host.dart';
 import 'package:dart_libp2p/core/multiaddr.dart';
 import 'package:dart_libp2p/core/network/conn.dart';
 import 'package:dart_libp2p/core/peer/peer_id.dart';
+import 'package:dart_libp2p/p2p/multiaddr/codec.dart';
+
 
 
 /// Protocol ID for the holepunch protocol
@@ -66,3 +68,14 @@ Conn? getDirectConnection(Host host, PeerId peerId) {
   }
   return null;
 }
+
+/// Encodes a protocol buffer message with a varint length prefix for go-libp2p pbio compatibility.
+Uint8List encodeDelimitedMessage(dynamic message) {
+  final messageBytes = (message as dynamic).writeToBuffer() as List<int>;
+  final lengthBytes = MultiAddrCodec.encodeVarint(messageBytes.length);
+  final result = Uint8List(lengthBytes.length + messageBytes.length);
+  result.setAll(0, lengthBytes);
+  result.setAll(lengthBytes.length, messageBytes);
+  return result;
+}
+

--- a/lib/p2p/protocol/holepunch/util.dart
+++ b/lib/p2p/protocol/holepunch/util.dart
@@ -7,6 +7,7 @@ import 'package:dart_libp2p/core/multiaddr.dart';
 import 'package:dart_libp2p/core/network/conn.dart';
 import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/p2p/multiaddr/codec.dart';
+import 'package:protobuf/protobuf.dart';
 
 
 
@@ -70,12 +71,11 @@ Conn? getDirectConnection(Host host, PeerId peerId) {
 }
 
 /// Encodes a protocol buffer message with a varint length prefix for go-libp2p pbio compatibility.
-Uint8List encodeDelimitedMessage(dynamic message) {
-  final messageBytes = (message as dynamic).writeToBuffer() as List<int>;
+Uint8List encodeDelimitedMessage(GeneratedMessage message) {
+  final messageBytes = message.writeToBuffer();
   final lengthBytes = MultiAddrCodec.encodeVarint(messageBytes.length);
   final result = Uint8List(lengthBytes.length + messageBytes.length);
   result.setAll(0, lengthBytes);
   result.setAll(lengthBytes.length, messageBytes);
   return result;
 }
-

--- a/lib/p2p/transport/tcp_transport.dart
+++ b/lib/p2p/transport/tcp_transport.dart
@@ -40,7 +40,7 @@ class TCPTransport implements Transport {
        _connManager = connManager ?? ConnectionManager();
 
   @override
-  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout}) async {
+  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout, bool simultaneousConnect = false}) async {
     final host = addr.valueForProtocol('ip4') ?? addr.valueForProtocol('ip6');
     final port = int.parse(addr.valueForProtocol('tcp') ?? '0');
 

--- a/lib/p2p/transport/transport.dart
+++ b/lib/p2p/transport/transport.dart
@@ -10,9 +10,16 @@ abstract class Transport {
   /// The configuration for this transport
   TransportConfig get config;
 
-  /// Dials a peer at the given multiaddress with optional timeout override
-  /// Returns a connection to the peer if successful
-  Future<Conn> dial(MultiAddr addr, {Duration? timeout});
+  /// Dials a peer at the given multiaddress with optional timeout override.
+  /// Returns a connection to the peer if successful.
+  ///
+  /// [simultaneousConnect] signals that this dial is a DCUtR
+  /// simultaneous-connect (hole-punch) attempt rather than an ordinary dial.
+  /// Transports that support NAT hole-punching may use this to change how
+  /// the dial is performed — e.g. reusing an active listener's socket so
+  /// the dial originates from the address already advertised to the peer.
+  /// Transports that don't support hole-punching may ignore it.
+  Future<Conn> dial(MultiAddr addr, {Duration? timeout, bool simultaneousConnect = false});
 
   /// Starts listening on the given multiaddress
   /// Returns a listener that can accept incoming connections

--- a/lib/p2p/transport/udx_transport.dart
+++ b/lib/p2p/transport/udx_transport.dart
@@ -44,6 +44,17 @@ class UDXTransport implements Transport {
   final Set<UDXSessionConn> _activeDialerConns = {};
   // static int _nextDialStreamIdPairBase = 1; // Removed static counter
 
+  // The multiplexer(s) backing this transport's active listener(s), keyed by
+  // IP family (true = IPv6, false = IPv4). DCUtR's simultaneous-connect
+  // requires the punch dial to originate from the SAME local socket whose
+  // external NAT mapping was already advertised in the CONNECT message — a
+  // fresh ephemeral dial socket gets a different, unadvertised mapping and
+  // the punch times out. When a listener is active for the target's address
+  // family, _performDial reuses its multiplexer (dart_udx routes by CID, so
+  // one physical socket safely hosts both the listener's inbound sessions
+  // and this outbound dial).
+  final Map<bool, UDXMultiplexer> _listenerMultiplexers = {};
+
   /// Optional metrics observer for UDX transport events
   UdxMetricsObserver? metricsObserver;
   
@@ -68,8 +79,8 @@ class UDXTransport implements Transport {
   }
 
   @override
-  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout}) async {
-    _logger.fine('[UDXTransport.dial] Attempting to dial $addr with timeout: ${timeout ?? config.dialTimeout}');
+  Future<TransportConn> dial(MultiAddr addr, {Duration? timeout, bool simultaneousConnect = false}) async {
+    _logger.fine('[UDXTransport.dial] Attempting to dial $addr with timeout: ${timeout ?? config.dialTimeout}, simultaneousConnect: $simultaneousConnect');
     final host = addr.valueForProtocol('ip4') ?? addr.valueForProtocol('ip6');
     final port = int.parse(addr.valueForProtocol('udp') ?? '0');
 
@@ -78,10 +89,10 @@ class UDXTransport implements Transport {
     }
 
     final effectiveTimeout = timeout ?? config.dialTimeout;
-    
+
     // Use UDX exception handler with retry logic for the entire dial operation
     return await UDXExceptionHandler.handleUDXOperation(
-      () => _performDial(addr, host, port, effectiveTimeout),
+      () => _performDial(addr, host, port, effectiveTimeout, simultaneousConnect),
       'UDXTransport.dial($addr)',
       retryConfig: UDXRetryConfig.regular,
     );
@@ -89,36 +100,62 @@ class UDXTransport implements Transport {
 
   /// Performs the actual dial operation with comprehensive resource cleanup
   Future<TransportConn> _performDial(
-    MultiAddr addr, 
-    String host, 
-    int port, 
+    MultiAddr addr,
+    String host,
+    int port,
     Duration effectiveTimeout,
+    bool simultaneousConnect,
   ) async {
     RawDatagramSocket? rawSocket;
     UDXMultiplexer? multiplexer;
     UDPSocket? udpSocket;
     UDXStream? initialStream;
-    
-    try {
-      _logger.fine('[UDXTransport._performDial] Creating RawDatagramSocket for $host');
-      
-      // Create raw UDP socket and bind it with UDX exception handling
-      final isIPv6 = UDX.getAddressFamily(host) == 6;
-      rawSocket = await UDXExceptionHandler.handleUDXOperation(
-        () => RawDatagramSocket.bind(
-          isIPv6 ? InternetAddress.anyIPv6 : InternetAddress.anyIPv4, 
-          0
-        ),
-        'RawDatagramSocket.bind($host)',
-      );
-      _logger.fine('[UDXTransport._performDial] RawDatagramSocket bound to: ${rawSocket!.address.address}:${rawSocket!.port}');
+    // True when this call created its own rawSocket/multiplexer and is
+    // therefore responsible for tearing it down on failure. When reusing a
+    // listener's multiplexer, ownership stays with that listener.
+    bool ownsMultiplexer = false;
 
-      // Create multiplexer with exception handling
-      multiplexer = await UDXExceptionHandler.handleUDXOperation(
-        () async => UDXMultiplexer(rawSocket!, metricsObserver: metricsObserver),
-        'UDXMultiplexer.create',
-      );
-      _logger.fine('[UDXTransport._performDial] UDXMultiplexer created');
+    try {
+      // DCUtR's simultaneous-connect requires the punch dial to originate
+      // from the SAME local socket whose external NAT mapping was already
+      // advertised in the CONNECT message — a fresh ephemeral dial socket
+      // gets a different, unadvertised mapping and the punch times out. When
+      // a listener is active for the target's address family AND this dial
+      // is itself a simultaneous-connect attempt, reuse the listener's
+      // multiplexer instead of binding a new socket (dart_udx routes by CID,
+      // so one physical socket safely hosts both the listener's inbound
+      // sessions and this outbound dial). Gating on simultaneousConnect
+      // keeps ordinary dials — including a transport dialing its own
+      // active listener, as in-process tests do — on their own fresh
+      // socket, where they belong.
+      final isIPv6 = UDX.getAddressFamily(host) == 6;
+      final reused = simultaneousConnect ? _listenerMultiplexers[isIPv6] : null;
+
+      if (reused != null) {
+        _logger.fine('[UDXTransport._performDial] Reusing active listener multiplexer (${reused.socket.address.address}:${reused.socket.port}) for dial to $host:$port — required for DCUtR simultaneous-connect.');
+        multiplexer = reused;
+        ownsMultiplexer = false;
+      } else {
+        _logger.fine('[UDXTransport._performDial] No active listener for this address family; creating RawDatagramSocket for $host');
+
+        // Create raw UDP socket and bind it with UDX exception handling
+        rawSocket = await UDXExceptionHandler.handleUDXOperation(
+          () => RawDatagramSocket.bind(
+            isIPv6 ? InternetAddress.anyIPv6 : InternetAddress.anyIPv4,
+            0
+          ),
+          'RawDatagramSocket.bind($host)',
+        );
+        _logger.fine('[UDXTransport._performDial] RawDatagramSocket bound to: ${rawSocket!.address.address}:${rawSocket!.port}');
+
+        // Create multiplexer with exception handling
+        multiplexer = await UDXExceptionHandler.handleUDXOperation(
+          () async => UDXMultiplexer(rawSocket!, metricsObserver: metricsObserver),
+          'UDXMultiplexer.create',
+        );
+        ownsMultiplexer = true;
+        _logger.fine('[UDXTransport._performDial] UDXMultiplexer created');
+      }
 
       // Create UDPSocket through multiplexer with exception handling
       udpSocket = await UDXExceptionHandler.handleUDXOperation(
@@ -205,8 +242,9 @@ class UDXTransport implements Transport {
         }
       }
 
-      final localProtocol = rawSocket.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
-      final localMa = MultiAddr('/$localProtocol/${rawSocket.address.address}/udp/${rawSocket.port}/udx');
+      final localSocket = multiplexer!.socket;
+      final localProtocol = localSocket.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+      final localMa = MultiAddr('/$localProtocol/${localSocket.address.address}/udp/${localSocket.port}/udx');
       final remoteMa = addr;
 
       _logger.fine('[UDXTransport._performDial] Creating UDXSessionConn for $addr. Local: $localMa, Remote: $remoteMa');
@@ -231,13 +269,16 @@ class UDXTransport implements Transport {
     } catch (error) {
       _logger.warning('[UDXTransport._performDial] Error during dial to $addr: $error. Performing cleanup.');
       
-      // Comprehensive resource cleanup using UDXExceptionUtils
+      // Comprehensive resource cleanup using UDXExceptionUtils.
+      // Only close the multiplexer/rawSocket if this dial created them — a
+      // reused listener multiplexer must keep serving that listener's
+      // inbound sessions after a failed dial attempt.
       await UDXExceptionUtils.safeCloseAll({
         'initialStream': () async => await initialStream?.close(),
-        'multiplexer': () async => multiplexer?.close(),
-        'rawSocket': () async => rawSocket?.close(),
+        if (ownsMultiplexer) 'multiplexer': () async => multiplexer?.close(),
+        if (ownsMultiplexer) 'rawSocket': () async => rawSocket?.close(),
       });
-      
+
       rethrow; // Let UDXExceptionHandler handle the retry logic
     }
   }
@@ -269,7 +310,13 @@ class UDXTransport implements Transport {
       multiplexer = UDXMultiplexer(rawSocket, metricsObserver: metricsObserver);
       _logger.fine('[UDXTransport.listen] UDXMultiplexer created');
 
-      final protocol = rawSocket.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+      final isIPv6 = rawSocket.address.type == InternetAddressType.IPv6;
+      // Register this listener's multiplexer so a subsequent DCUtR punch
+      // dial to a peer of the same address family reuses this socket's NAT
+      // mapping instead of opening a fresh, unadvertised one.
+      _listenerMultiplexers[isIPv6] = multiplexer;
+
+      final protocol = isIPv6 ? 'ip6' : 'ip4';
       final boundMa = MultiAddr('/$protocol/${rawSocket.address.address}/udp/${rawSocket.port}/udx');
       _logger.fine('[UDXTransport.listen] Creating UDXListener for $boundMa');
       final listener = UDXListener(
@@ -323,6 +370,7 @@ class UDXTransport implements Transport {
       }
     }
     _activeListeners.clear();
+    _listenerMultiplexers.clear();
     _logger.fine('[UDXTransport.dispose] All active listeners closed and cleared.');
 
     for (final conn in _activeDialerConns.toList()) { 
@@ -555,9 +603,16 @@ class UDXSessionConn implements MuxedConn, TransportConn {
     final expectedRemoteHost = _remoteMultiaddr.valueForProtocol(remoteAddress.type == InternetAddressType.IPv4 ? 'ip4' : 'ip6');
     final expectedRemotePort = int.parse(_remoteMultiaddr.valueForProtocol('udp')!);
 
-    if (remoteAddress.address != expectedRemoteHost || remotePort != expectedRemotePort) {
+    // Accept on port-only match as a fallback. Through NAT, the source IP a
+    // punch/new-stream packet actually arrives from can differ from what was
+    // advertised (the peer's NAT may egress a different address than the one
+    // it's mapped as); the port is the more reliable identifier here.
+    if (remotePort != expectedRemotePort) {
       _logger.fine('[UDXSessionConn $id] (Dialer): Received unmatched packet from unexpected source ${remoteAddress.address}:$remotePort. Expected $expectedRemoteHost:$expectedRemotePort. Ignoring.');
       return;
+    }
+    if (remoteAddress.address != expectedRemoteHost) {
+      _logger.info('[UDXSessionConn $id] (Dialer): Accepting unmatched packet on port-only match — source IP ${remoteAddress.address} differs from expected $expectedRemoteHost (through-NAT discrepancy), port $remotePort matches.');
     }
     
     try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,8 +25,7 @@ dependencies:
 
   base_x: ^2.0.0
 
-  dart_udx:
-    path: ../dart-udx
+  dart_udx: ^2.0.3
 
   dcid: ^1.0.0
 
@@ -48,7 +47,3 @@ dev_dependencies:
   test: ^1.24.0
   protoc_plugin: ^21.1.2
   lints: ^2.1.0
-
-dependency_overrides:
-  dart_udx:
-    path: ../dart-udx

--- a/test/core/network/context_force_direct_test.dart
+++ b/test/core/network/context_force_direct_test.dart
@@ -1,0 +1,20 @@
+import 'package:dart_libp2p/core/network/context.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('force-direct dial context', () {
+    test('accepts the public string-valued helper', () {
+      expect(
+        Context().withForceDirectDial('hole-punch').getForceDirectDial(),
+        (true, 'hole-punch'),
+      );
+    });
+
+    test('accepts the bool-valued form used by the responder', () {
+      expect(
+        Context().withValue('forceDirectDial', true).getForceDirectDial(),
+        (true, 'true'),
+      );
+    });
+  });
+}

--- a/test/network/swarm_integrated_test.mocks.dart
+++ b/test/network/swarm_integrated_test.mocks.dart
@@ -1251,19 +1251,26 @@ class SwarmTestMockTransport extends _i1.Mock implements _i23.Transport {
   _i5.Future<_i6.Conn> dial(
     _i9.MultiAddr? addr, {
     Duration? timeout,
+    bool? simultaneousConnect = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #dial,
           [addr],
-          {#timeout: timeout},
+          {
+            #timeout: timeout,
+            #simultaneousConnect: simultaneousConnect,
+          },
         ),
         returnValue: _i5.Future<_i6.Conn>.value(_FakeConn_9(
           this,
           Invocation.method(
             #dial,
             [addr],
-            {#timeout: timeout},
+            {
+              #timeout: timeout,
+              #simultaneousConnect: simultaneousConnect,
+            },
           ),
         )),
       ) as _i5.Future<_i6.Conn>);

--- a/test/p2p/host/basic_host_address_family_test.dart
+++ b/test/p2p/host/basic_host_address_family_test.dart
@@ -1,0 +1,17 @@
+import 'package:dart_libp2p/core/multiaddr.dart';
+import 'package:dart_libp2p/p2p/host/basic/basic_host.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('unspecified listeners only expand onto the same IP family', () {
+    final v4Listen = MultiAddr('/ip4/0.0.0.0/udp/4001/udx');
+    final v6Listen = MultiAddr('/ip6/::/udp/4001/udx');
+    final v4Interface = MultiAddr('/ip4/10.0.0.2');
+    final v6Interface = MultiAddr('/ip6/2001:db8::2');
+
+    expect(addressesShareIPFamily(v4Listen, v4Interface), isTrue);
+    expect(addressesShareIPFamily(v6Listen, v6Interface), isTrue);
+    expect(addressesShareIPFamily(v4Listen, v6Interface), isFalse);
+    expect(addressesShareIPFamily(v6Listen, v4Interface), isFalse);
+  });
+}

--- a/test/protocol/circuitv2/relay_half_close_test.mocks.dart
+++ b/test/protocol/circuitv2/relay_half_close_test.mocks.dart
@@ -500,19 +500,26 @@ class MockCircuitV2Client extends _i1.Mock implements _i17.CircuitV2Client {
   _i16.Future<_i10.TransportConn> dial(
     _i13.MultiAddr? addr, {
     Duration? timeout,
+    bool? simultaneousConnect = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #dial,
           [addr],
-          {#timeout: timeout},
+          {
+            #timeout: timeout,
+            #simultaneousConnect: simultaneousConnect,
+          },
         ),
         returnValue: _i16.Future<_i10.TransportConn>.value(_FakeTransportConn_9(
           this,
           Invocation.method(
             #dial,
             [addr],
-            {#timeout: timeout},
+            {
+              #timeout: timeout,
+              #simultaneousConnect: simultaneousConnect,
+            },
           ),
         )),
       ) as _i16.Future<_i10.TransportConn>);

--- a/test/protocol/holepunch/holepunch_util_test.dart
+++ b/test/protocol/holepunch/holepunch_util_test.dart
@@ -5,12 +5,15 @@ import 'package:dart_libp2p/core/peer/peer_id.dart';
 import 'package:dart_libp2p/core/host/host.dart';
 import 'package:dart_libp2p/core/network/network.dart';
 import 'package:dart_libp2p/core/network/conn.dart';
+import 'package:dart_libp2p/core/network/stream.dart';
+import 'package:dart_libp2p/p2p/protocol/circuitv2/util/buffered_reader.dart';
+import 'package:dart_libp2p/p2p/protocol/holepunch/pb/holepunch.pb.dart';
 import 'package:dart_libp2p/p2p/protocol/holepunch/util.dart';
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
 
-@GenerateMocks([Host, Network, Conn])
+@GenerateMocks([Host, Network, Conn, P2PStream])
 import 'holepunch_util_test.mocks.dart';
 
 void main() {
@@ -34,9 +37,10 @@ void main() {
 
     group('Relay Address Detection', () {
       test('should detect relay addresses correctly', () {
-        final relayAddr = MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay/p2p-circuit');
+        final relayAddr =
+            MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay/p2p-circuit');
         final directAddr = MultiAddr('/ip4/127.0.0.1/tcp/4001');
-        
+
         expect(isRelayAddress(relayAddr), isTrue);
         expect(isRelayAddress(directAddr), isFalse);
       });
@@ -53,17 +57,20 @@ void main() {
           MultiAddr('/ip4/127.0.0.1/tcp/4001'), // direct
           MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay/p2p-circuit'), // relay
           MultiAddr('/ip6/::1/tcp/4003'), // direct
-          MultiAddr('/ip4/192.168.1.100/tcp/4004/p2p/QmRelay2/p2p-circuit'), // relay
+          MultiAddr(
+              '/ip4/192.168.1.100/tcp/4004/p2p/QmRelay2/p2p-circuit'), // relay
         ];
 
         final filteredAddresses = removeRelayAddrs(addresses);
-        
+
         expect(filteredAddresses, hasLength(2));
-        expect(filteredAddresses[0].toString(), contains('/ip4/127.0.0.1/tcp/4001'));
+        expect(filteredAddresses[0].toString(),
+            contains('/ip4/127.0.0.1/tcp/4001'));
         expect(filteredAddresses[1].toString(), contains('/ip6/::1/tcp/4003'));
       });
 
-      test('should return empty list when all addresses are relay addresses', () {
+      test('should return empty list when all addresses are relay addresses',
+          () {
         final addresses = [
           MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay1/p2p-circuit'),
           MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay2/p2p-circuit'),
@@ -112,7 +119,9 @@ void main() {
       test('should skip invalid bytes during deserialization', () {
         final validAddr = MultiAddr('/ip4/127.0.0.1/tcp/4001');
         final validBytes = [validAddr.toBytes()];
-        final invalidBytes = [Uint8List.fromList([1, 2, 3])]; // Invalid multiaddr bytes
+        final invalidBytes = [
+          Uint8List.fromList([1, 2, 3])
+        ]; // Invalid multiaddr bytes
 
         final mixedBytes = [...validBytes, ...invalidBytes];
         final reconverted = addrsFromBytes(mixedBytes);
@@ -125,17 +134,74 @@ void main() {
       test('should handle different input types for bytes', () {
         final addr = MultiAddr('/ip4/127.0.0.1/tcp/4001');
         final addrBytes = addr.toBytes();
-        
+
         // Test with Uint8List
         final fromUint8List = addrsFromBytes([addrBytes]);
         expect(fromUint8List, hasLength(1));
-        
+
         // Test with List<int>
         final fromListInt = addrsFromBytes([addrBytes.toList()]);
         expect(fromListInt, hasLength(1));
-        
+
         // Both should produce same result
         expect(fromUint8List[0].toString(), equals(fromListInt[0].toString()));
+      });
+    });
+
+    group('Delimited Message Encoding & Varint Framing', () {
+      test('prepends the protobuf payload length as a uvarint', () {
+        final message = HolePunch()
+          ..type = HolePunch_Type.CONNECT
+          ..obsAddrs.add(Uint8List.fromList([1, 2, 3, 4]));
+        final payload = message.writeToBuffer();
+
+        final encoded = encodeDelimitedMessage(message);
+        final prefix = _decodeUvarint(encoded);
+
+        expect(prefix.value, payload.length);
+        expect(encoded.sublist(prefix.byteLength), payload);
+      });
+
+      test('uses a multi-byte uvarint for payloads larger than 127 bytes', () {
+        final message = HolePunch()
+          ..type = HolePunch_Type.CONNECT
+          ..obsAddrs.add(Uint8List(256));
+        final payload = message.writeToBuffer();
+
+        final encoded = encodeDelimitedMessage(message);
+        final prefix = _decodeUvarint(encoded);
+
+        expect(payload.length, greaterThan(127));
+        expect(prefix.byteLength, greaterThan(1));
+        expect(prefix.value, payload.length);
+        expect(encoded.sublist(prefix.byteLength), payload);
+      });
+
+      test('buffered reader reads a fragmented delimited message', () async {
+        final message = HolePunch()
+          ..type = HolePunch_Type.CONNECT
+          ..obsAddrs.add(Uint8List(256));
+        final encoded = encodeDelimitedMessage(message);
+        final chunks = <Uint8List>[
+          Uint8List.fromList(encoded.sublist(0, 1)),
+          Uint8List.fromList(encoded.sublist(1, 17)),
+          Uint8List.fromList(encoded.sublist(17)),
+        ];
+        var nextChunk = 0;
+        final stream = MockP2PStream();
+        when(stream.read()).thenAnswer(
+          (_) async =>
+              nextChunk < chunks.length ? chunks[nextChunk++] : Uint8List(0),
+        );
+
+        final reader = BufferedP2PStreamReader(stream);
+        final payloadLength = await reader.readVarint();
+        final payload = await reader.readExact(payloadLength);
+        final decoded = HolePunch.fromBuffer(payload);
+
+        expect(payloadLength, message.writeToBuffer().length);
+        expect(decoded.type, HolePunch_Type.CONNECT);
+        expect(decoded.obsAddrs.single, Uint8List(256));
       });
     });
 
@@ -148,43 +214,46 @@ void main() {
         mockHost = MockHost();
         mockNetwork = MockNetwork();
         testPeerId = await PeerId.random();
-        
+
         when(mockHost.network).thenReturn(mockNetwork);
       });
 
       test('should return direct connection when available', () {
         final mockDirectConn = MockConn();
         final mockRelayConn = MockConn();
-        
+
         final directAddr = MultiAddr('/ip4/127.0.0.1/tcp/4001');
-        final relayAddr = MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay/p2p-circuit');
-        
+        final relayAddr =
+            MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay/p2p-circuit');
+
         when(mockDirectConn.remoteMultiaddr).thenReturn(directAddr);
         when(mockRelayConn.remoteMultiaddr).thenReturn(relayAddr);
-        
+
         when(mockNetwork.connsToPeer(testPeerId))
             .thenReturn([mockRelayConn, mockDirectConn]);
 
         final directConn = getDirectConnection(mockHost, testPeerId);
-        
+
         expect(directConn, equals(mockDirectConn));
       });
 
       test('should return null when only relay connections exist', () {
         final mockRelayConn1 = MockConn();
         final mockRelayConn2 = MockConn();
-        
-        final relayAddr1 = MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay1/p2p-circuit');
-        final relayAddr2 = MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay2/p2p-circuit');
-        
+
+        final relayAddr1 =
+            MultiAddr('/ip4/127.0.0.1/tcp/4001/p2p/QmRelay1/p2p-circuit');
+        final relayAddr2 =
+            MultiAddr('/ip4/127.0.0.1/tcp/4002/p2p/QmRelay2/p2p-circuit');
+
         when(mockRelayConn1.remoteMultiaddr).thenReturn(relayAddr1);
         when(mockRelayConn2.remoteMultiaddr).thenReturn(relayAddr2);
-        
+
         when(mockNetwork.connsToPeer(testPeerId))
             .thenReturn([mockRelayConn1, mockRelayConn2]);
 
         final directConn = getDirectConnection(mockHost, testPeerId);
-        
+
         expect(directConn, isNull);
       });
 
@@ -192,27 +261,41 @@ void main() {
         when(mockNetwork.connsToPeer(testPeerId)).thenReturn([]);
 
         final directConn = getDirectConnection(mockHost, testPeerId);
-        
+
         expect(directConn, isNull);
       });
 
       test('should return first direct connection when multiple exist', () {
         final mockDirectConn1 = MockConn();
         final mockDirectConn2 = MockConn();
-        
+
         final directAddr1 = MultiAddr('/ip4/127.0.0.1/tcp/4001');
         final directAddr2 = MultiAddr('/ip4/127.0.0.1/tcp/4002');
-        
+
         when(mockDirectConn1.remoteMultiaddr).thenReturn(directAddr1);
         when(mockDirectConn2.remoteMultiaddr).thenReturn(directAddr2);
-        
+
         when(mockNetwork.connsToPeer(testPeerId))
             .thenReturn([mockDirectConn1, mockDirectConn2]);
 
         final directConn = getDirectConnection(mockHost, testPeerId);
-        
+
         expect(directConn, equals(mockDirectConn1));
       });
     });
   });
+}
+
+({int value, int byteLength}) _decodeUvarint(Uint8List bytes) {
+  var value = 0;
+  var shift = 0;
+  for (var index = 0; index < bytes.length; index++) {
+    final byte = bytes[index];
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) == 0) {
+      return (value: value, byteLength: index + 1);
+    }
+    shift += 7;
+  }
+  throw StateError('unterminated uvarint');
 }

--- a/test/protocol/holepunch/holepunch_util_test.mocks.dart
+++ b/test/protocol/holepunch/holepunch_util_test.mocks.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i13;
+import 'dart:typed_data' as _i19;
 
 import 'package:dart_libp2p/core/connmgr/conn_manager.dart' as _i6;
 import 'package:dart_libp2p/core/crypto/keys.dart' as _i18;
@@ -161,6 +162,27 @@ class _FakeConnStats_11 extends _i1.SmartFake implements _i10.ConnStats {
 
 class _FakeConnScope_12 extends _i1.SmartFake implements _i9.ConnScope {
   _FakeConnScope_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStreamStats_13 extends _i1.SmartFake implements _i8.StreamStats {
+  _FakeStreamStats_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStreamManagementScope_14 extends _i1.SmartFake
+    implements _i9.StreamManagementScope {
+  _FakeStreamManagementScope_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -693,4 +715,202 @@ class MockConn extends _i1.Mock implements _i10.Conn {
           ),
         )),
       ) as _i13.Future<_i8.P2PStream<dynamic>>);
+}
+
+/// A class which mocks [P2PStream].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockP2PStream<T> extends _i1.Mock implements _i8.P2PStream<T> {
+  MockP2PStream() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i10.Conn get conn => (super.noSuchMethod(
+        Invocation.getter(#conn),
+        returnValue: _FakeConn_8(
+          this,
+          Invocation.getter(#conn),
+        ),
+      ) as _i10.Conn);
+
+  @override
+  _i8.P2PStream<_i19.Uint8List> get incoming => (super.noSuchMethod(
+        Invocation.getter(#incoming),
+        returnValue: _FakeP2PStream_6<_i19.Uint8List>(
+          this,
+          Invocation.getter(#incoming),
+        ),
+      ) as _i8.P2PStream<_i19.Uint8List>);
+
+  @override
+  bool get isClosed => (super.noSuchMethod(
+        Invocation.getter(#isClosed),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get isWritable => (super.noSuchMethod(
+        Invocation.getter(#isWritable),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  String id() => (super.noSuchMethod(
+        Invocation.method(
+          #id,
+          [],
+        ),
+        returnValue: _i17.dummyValue<String>(
+          this,
+          Invocation.method(
+            #id,
+            [],
+          ),
+        ),
+      ) as String);
+
+  @override
+  String protocol() => (super.noSuchMethod(
+        Invocation.method(
+          #protocol,
+          [],
+        ),
+        returnValue: _i17.dummyValue<String>(
+          this,
+          Invocation.method(
+            #protocol,
+            [],
+          ),
+        ),
+      ) as String);
+
+  @override
+  _i13.Future<void> setProtocol(String? id) => (super.noSuchMethod(
+        Invocation.method(
+          #setProtocol,
+          [id],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i8.StreamStats stat() => (super.noSuchMethod(
+        Invocation.method(
+          #stat,
+          [],
+        ),
+        returnValue: _FakeStreamStats_13(
+          this,
+          Invocation.method(
+            #stat,
+            [],
+          ),
+        ),
+      ) as _i8.StreamStats);
+
+  @override
+  _i9.StreamManagementScope scope() => (super.noSuchMethod(
+        Invocation.method(
+          #scope,
+          [],
+        ),
+        returnValue: _FakeStreamManagementScope_14(
+          this,
+          Invocation.method(
+            #scope,
+            [],
+          ),
+        ),
+      ) as _i9.StreamManagementScope);
+
+  @override
+  _i13.Future<_i19.Uint8List> read([int? maxLength]) => (super.noSuchMethod(
+        Invocation.method(
+          #read,
+          [maxLength],
+        ),
+        returnValue: _i13.Future<_i19.Uint8List>.value(_i19.Uint8List(0)),
+      ) as _i13.Future<_i19.Uint8List>);
+
+  @override
+  _i13.Future<void> write(_i19.Uint8List? data) => (super.noSuchMethod(
+        Invocation.method(
+          #write,
+          [data],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> close() => (super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> closeWrite() => (super.noSuchMethod(
+        Invocation.method(
+          #closeWrite,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> closeRead() => (super.noSuchMethod(
+        Invocation.method(
+          #closeRead,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> reset() => (super.noSuchMethod(
+        Invocation.method(
+          #reset,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> setDeadline(DateTime? time) => (super.noSuchMethod(
+        Invocation.method(
+          #setDeadline,
+          [time],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> setReadDeadline(DateTime? time) => (super.noSuchMethod(
+        Invocation.method(
+          #setReadDeadline,
+          [time],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> setWriteDeadline(DateTime? time) => (super.noSuchMethod(
+        Invocation.method(
+          #setWriteDeadline,
+          [time],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }

--- a/test/protocol/ping_test.mocks.dart
+++ b/test/protocol/ping_test.mocks.dart
@@ -1079,19 +1079,26 @@ class PingTestMockTransport extends _i1.Mock implements _i22.Transport {
   _i16.Future<_i10.Conn> dial(
     _i15.MultiAddr? addr, {
     Duration? timeout,
+    bool? simultaneousConnect = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #dial,
           [addr],
-          {#timeout: timeout},
+          {
+            #timeout: timeout,
+            #simultaneousConnect: simultaneousConnect,
+          },
         ),
         returnValue: _i16.Future<_i10.Conn>.value(_FakeConn_8(
           this,
           Invocation.method(
             #dial,
             [addr],
-            {#timeout: timeout},
+            {
+              #timeout: timeout,
+              #simultaneousConnect: simultaneousConnect,
+            },
           ),
         )),
       ) as _i16.Future<_i10.Conn>);

--- a/test/transport/udx_stream_adapter_test.mocks.dart
+++ b/test/transport/udx_stream_adapter_test.mocks.dart
@@ -1702,12 +1702,16 @@ class MockUDXTransport extends _i1.Mock implements _i25.UDXTransport {
   _i22.Future<_i18.TransportConn> dial(
     _i4.MultiAddr? addr, {
     Duration? timeout,
+    bool? simultaneousConnect = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #dial,
           [addr],
-          {#timeout: timeout},
+          {
+            #timeout: timeout,
+            #simultaneousConnect: simultaneousConnect,
+          },
         ),
         returnValue:
             _i22.Future<_i18.TransportConn>.value(_FakeTransportConn_20(
@@ -1715,7 +1719,10 @@ class MockUDXTransport extends _i1.Mock implements _i25.UDXTransport {
           Invocation.method(
             #dial,
             [addr],
-            {#timeout: timeout},
+            {
+              #timeout: timeout,
+              #simultaneousConnect: simultaneousConnect,
+            },
           ),
         )),
       ) as _i22.Future<_i18.TransportConn>);

--- a/test/transport/udx_transport_test.dart
+++ b/test/transport/udx_transport_test.dart
@@ -69,6 +69,41 @@ void main() {
     });
 
     group('Connection Establishment', () {
+      test('simultaneous connect reuses the advertised listener socket', () async {
+        final remoteTransport = UDXTransport(
+          config: config,
+          connManager: ConnectionManager(
+            idleTimeout: const Duration(minutes: 5),
+            shutdownTimeout: const Duration(seconds: 30),
+          ),
+        );
+        final localListener = await transport.listen(
+          MultiAddr('/ip4/127.0.0.1/udp/0/udx'),
+        );
+        final remoteListener = await remoteTransport.listen(
+          MultiAddr('/ip4/127.0.0.1/udp/0/udx'),
+        );
+        final incomingConnection = remoteListener.connectionStream.first;
+
+        final dialerConnection = await transport.dial(
+          remoteListener.addr,
+          simultaneousConnect: true,
+        );
+        final listenerConnection = await incomingConnection;
+
+        expect(
+          dialerConnection.localMultiaddr.valueForProtocol('udp'),
+          localListener.addr.valueForProtocol('udp'),
+          reason: 'DCUtR must dial from the socket advertised to the peer',
+        );
+
+        await dialerConnection.close();
+        await listenerConnection.close();
+        await localListener.close();
+        await remoteListener.close();
+        await remoteTransport.dispose();
+      });
+
       test('should establish connection between listener and dialer', () async {
         print('Starting connection test...');
         final listenerAddr = MultiAddr('/ip4/127.0.0.1/udp/0/udx');


### PR DESCRIPTION
## Summary

This replaces #16 and #18 with one clean branch based on the current `main`. It fixes the complete DCUtR path found while testing a physical Android client against a go-libp2p gateway:

- accept both public string-valued and internal bool-valued force-direct contexts;
- bypass relay connections when DCUtR asks for a direct dial;
- propagate `simultaneousConnect` from Swarm into the transport;
- reuse the active UDX listener socket for a simultaneous punch dial, preserving the NAT mapping advertised in CONNECT;
- use unsigned-varint length-delimited protobuf framing compatible with go-libp2p `pbio`;
- buffer stream reads so a frame may arrive split across reads or alongside the next frame;
- stop BasicHost from synthesizing cross-family listen addresses (for example an IPv4 listener port attached to an IPv6 interface);
- replace the repository-local `../dart-udx` dependency with the published `dart_udx` package so a fresh checkout resolves.

## Why all pieces belong together

#15 and #17 describe different visible failures in the same handshake. Correct framing gets the peers through CONNECT/SYNC; force-direct propagation and listener-socket reuse make the resulting simultaneous dial traverse NAT. #19 fixes invalid candidates that otherwise poison identify, AutoNAT, and DCUtR address selection.

## Tests

Added regression coverage for:

- bool and string force-direct context values;
- same-family listen-address expansion;
- unsigned-varint framing, multi-byte lengths, fragmented reads, and coalesced frames;
- simultaneous UDX dial reusing the advertised listener UDP port.

Verification performed on this branch:

- `dart test test/core/network/context_force_direct_test.dart test/p2p/host/basic_host_address_family_test.dart test/protocol/holepunch/` — 74 passed
- `dart test test/transport/udx_transport_test.dart` — 11 passed
- `dart test test/host/basic_host_addr_filter_test.dart` — 2 passed
- targeted `dart analyze` — no errors (existing warnings remain)
- merge-tree against current upstream `main` — no conflicts

`test/network/swarm_integrated_test.dart` now compiles after regenerating mocks, but its existing `mockAddrBook.addAddrs(...)` Mockito stub fails at runtime. That failure is unrelated to DCUtR and occurs before the changed dial path.

The combined behavior was also verified against go-libp2p using real Android hardware over cellular: DCUtR reported a successful hole punch and established a direct connection.

Closes #15
Closes #17
Closes #19

Supersedes #16 and #18.
