### PR TITLE
fix(transport): tag TCP listen/dial addrs with actual socket family

### DIFF
--- a/lib/p2p/transport/tcp_listener.dart
+++ b/lib/p2p/transport/tcp_listener.dart
@@ -45,8 +45,10 @@ class TCPListener implements Listener {
 
   void _handleConnection(Socket socket) async {
     // Create multiaddrs for local and remote endpoints from the accepted socket
-    final localRealAddr = MultiAddr('/ip4/${socket.address.address}/tcp/${socket.port}');
-    final remoteRealAddr = MultiAddr('/ip4/${socket.remoteAddress.address}/tcp/${socket.remotePort}');
+    final localProtocol = socket.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+    final remoteProtocol = socket.remoteAddress.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+    final localRealAddr = MultiAddr('/$localProtocol/${socket.address.address}/tcp/${socket.port}');
+    final remoteRealAddr = MultiAddr('/$remoteProtocol/${socket.remoteAddress.address}/tcp/${socket.remotePort}');
     
     try {
       final connection = await _onConnection(socket, localRealAddr, remoteRealAddr);

--- a/lib/p2p/transport/tcp_transport.dart
+++ b/lib/p2p/transport/tcp_transport.dart
@@ -64,8 +64,10 @@ class TCPTransport implements Transport {
       );
 
       // Create multiaddrs for local and remote endpoints
-      final localAddr = MultiAddr('/ip4/${socket.address.address}/tcp/${socket.port}');
-      final remoteAddr = MultiAddr('/ip4/${socket.remoteAddress.address}/tcp/${socket.remotePort}');
+      final localProtocol = socket.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+      final remoteProtocol = socket.remoteAddress.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+      final localAddr = MultiAddr('/$localProtocol/${socket.address.address}/tcp/${socket.port}');
+      final remoteAddr = MultiAddr('/$remoteProtocol/${socket.remoteAddress.address}/tcp/${socket.remotePort}');
 
       // Placeholder PeerIDs - these should be derived from a security handshake
       // which typically happens before or as part of the transport upgrade process.
@@ -112,7 +114,8 @@ class TCPTransport implements Transport {
     try {
       final server = await ServerSocket.bind(host, port);
       // Create a new multiaddr with the actual port that was assigned
-      final boundAddr = MultiAddr('/ip4/$host/tcp/${server.port}');
+      final boundProtocol = server.address.type == InternetAddressType.IPv6 ? 'ip6' : 'ip4';
+      final boundAddr = MultiAddr('/$boundProtocol/$host/tcp/${server.port}');
       final listener = TCPListener(
         server,
         addr: boundAddr,

--- a/test/transport/tcp_ipv6_listen_test.dart
+++ b/test/transport/tcp_ipv6_listen_test.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:dart_libp2p/core/multiaddr.dart';
+import 'package:dart_libp2p/core/network/rcmgr.dart';
+import 'package:dart_libp2p/p2p/network/connmgr/null_conn_mgr.dart';
+import 'package:dart_libp2p/p2p/transport/listener.dart';
+import 'package:dart_libp2p/p2p/transport/tcp_transport.dart';
+import 'package:test/test.dart';
+
+// Regression test for issue: dart_libp2p crashes on IPv6 listen
+// (observed-addr FormatException). TCPTransport.listen()/dial() and
+// TCPListener._handleConnection() used to hardcode the "/ip4/" protocol tag
+// when building bound/local/remote multiaddrs, so listening or accepting a
+// connection on an IPv6 socket produced a malformed multiaddr like
+// "/ip4/::1/tcp/1234" and MultiAddr's codec/validator threw
+// FormatException('Invalid IPv4 address').
+void main() {
+  group('TCPTransport IPv6', () {
+    late ResourceManager resourceManager;
+    late NullConnMgr connManager;
+    late TCPTransport transport;
+
+    setUp(() {
+      resourceManager = NullResourceManager();
+      connManager = NullConnMgr();
+      transport = TCPTransport(connManager: connManager, resourceManager: resourceManager);
+    });
+
+    tearDown(() async {
+      await transport.dispose();
+    });
+
+    test('listen on an IPv6 loopback addr does not throw and yields an /ip6 bound addr', () async {
+      final listenAddr = MultiAddr('/ip6/::1/tcp/0');
+
+      final Listener listener = await transport.listen(listenAddr);
+      // TCPListener.close() only completes once its (single-subscription)
+      // connectionStream has been listened to, so subscribe before closing.
+      final sub = listener.connectionStream.listen((_) {});
+      addTearDown(sub.cancel);
+      addTearDown(listener.close);
+
+      expect(listener.addr.hasProtocol('ip6'), isTrue);
+      expect(listener.addr.hasProtocol('ip4'), isFalse);
+      // Would previously throw FormatException before this assertion is
+      // ever reached, while building the bound addr.
+      expect(listener.addr.valueForProtocol('ip6'), '::1');
+    });
+
+    test('dialing an IPv6 listener succeeds and reports /ip6 local/remote addrs', () async {
+      final listener = await transport.listen(MultiAddr('/ip6/::1/tcp/0'));
+      addTearDown(listener.close);
+
+      final acceptedConns = <void>[];
+      final acceptSub = listener.connectionStream.listen((conn) {
+        acceptedConns.add(null);
+      });
+      addTearDown(acceptSub.cancel);
+
+      final conn = await transport.dial(listener.addr);
+      addTearDown(conn.close);
+
+      expect(conn.localMultiaddr.hasProtocol('ip6'), isTrue);
+      expect(conn.remoteMultiaddr.hasProtocol('ip6'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #21

## What

`TCPTransport.dial()`/`listen()` and `TCPListener._handleConnection()` hardcoded the `/ip4/` protocol tag when building local/remote/bound multiaddrs from a socket, regardless of the socket's actual address family. Listening or dialing on an IPv6 address produced a malformed multiaddr like `/ip4/::1/tcp/1234`, which the multiaddr codec/validator rejects with `FormatException('Invalid IPv4 address')` as soon as anything (e.g. the identify/observed-addr path) tries to parse it back — crashing `host.start()` for any IPv6 listener.

`UDXTransport` already derives the protocol tag from the socket's actual `InternetAddressType`; this makes TCP do the same, at all 5 call sites:

- `TCPTransport.dial()` — local/remote addr from the connected socket
- `TCPTransport.listen()` — bound addr from the server socket
- `TCPListener._handleConnection()` — local/remote addr for each accepted connection

## Test plan

Added `test/transport/tcp_ipv6_listen_test.dart`:
- listening on `/ip6/::1/tcp/0` no longer throws and yields an `/ip6` bound addr
- dialing that listener succeeds and reports `/ip6` local/remote addrs

Verified locally against both this fix and its parent (reproduces the crash on the parent, passes on this branch). Also ran the existing `tcp_noise_ping_test.dart` and `tcp_host_to_host.dart` suites — no regressions.