### PR TITLE
fix(swarm): add forceFreshDial to bypass healthy-conn reuse unconditionally

### DIFF
--- a/lib/core/network/context.dart
+++ b/lib/core/network/context.dart
@@ -54,6 +54,31 @@ class Context {
     return (false, '');
   }
 
+  /// Creates a new Context with the force fresh dial option. Unlike
+  /// [withForceDirectDial] (which only bypasses `Swarm.dialPeer`'s
+  /// existing-healthy-connection reuse when every healthy connection is
+  /// relayed — it exists to force a *direct* dial past a *relay* conn), this
+  /// unconditionally skips that reuse for one dial attempt regardless of the
+  /// existing connection's type. For a caller that has independent, specific
+  /// reason to believe a particular existing connection is broken (e.g. it
+  /// just observed a fast disconnect right after adopting it) even though
+  /// `_isConnectionHealthy` still reports it healthy — a stream-level RST
+  /// that doesn't close the underlying muxed session isn't reflected there
+  /// until the periodic health-probe loop catches up, which can take several
+  /// probe cycles. See stephanfeb/dart_libp2p#23.
+  Context withForceFreshDial(String reason) {
+    return withValue(_forceFreshDialKey, reason);
+  }
+
+  /// Gets the force fresh dial option from the Context
+  (bool, String) getForceFreshDial() {
+    final value = getValue(_forceFreshDialKey);
+    if (value != null) {
+      return (true, value is String ? value : value.toString());
+    }
+    return (false, '');
+  }
+
   /// Creates a new Context with the simultaneous connect option
   Context withSimultaneousConnect(bool isClient, String reason) {
     return withValue(
@@ -150,6 +175,7 @@ class Context {
 // Context keys
 const _noDialKey = 'noDial';
 const _forceDirectDialKey = 'forceDirectDial';
+const _forceFreshDialKey = 'forceFreshDial';
 const _allowLimitedConnKey = 'allowLimitedConn';
 const _simConnectIsServerKey = 'simConnectIsServer';
 const _simConnectIsClientKey = 'simConnectIsClient';

--- a/lib/p2p/network/swarm/swarm.dart
+++ b/lib/p2p/network/swarm/swarm.dart
@@ -786,11 +786,21 @@ class Swarm implements Network {
         }
       }
       
-      if (healthyConns.isNotEmpty) {
+      // forceFreshDial (stephanfeb/dart_libp2p#23): a caller sets this when
+      // it has independent, specific reason to believe a particular existing
+      // connection is actually broken even though `_isConnectionHealthy`
+      // still reports it healthy (e.g. it just observed a fast disconnect
+      // right after adopting the connection) — bypasses the healthy-conn
+      // reuse below unconditionally for one dial attempt.
+      final forceFreshDial = context.getForceFreshDial().$1;
+
+      if (healthyConns.isNotEmpty && !forceFreshDial) {
         // Prefer newest connection - more likely to be alive for relayed paths
         // where the end-to-end path can break without local detection
         _logger.warning('Swarm.dialPeer: Found healthy connection for peer ${peerId.toString()}. Returning newest connection ID: ${healthyConns.last.id}');
         return healthyConns.last;
+      } else if (healthyConns.isNotEmpty && forceFreshDial) {
+        _logger.fine('Swarm.dialPeer: forceFreshDial set for ${peerId.toString()} — dialing fresh addresses instead of reusing the existing connection.');
       } else {
         _logger.warning('Swarm.dialPeer: No healthy connections found for peer ${peerId.toString()}. Will create new connection.');
       }


### PR DESCRIPTION
Fixes #23.

Swarm.dialPeer's healthy-connection reuse returns a cached connection to a peer before ever consulting the caller's address list. A caller that has independent evidence a specific connection just died (e.g. an app-level fast-disconnect right after adopting it) has no way to skip reuse: _isConnectionHealthy only flips to unhealthy via an explicit health-state event or a periodic probe loop that needs 3 consecutive failures, both of which can lag well behind what the caller already knows.

Adds Context.withForceFreshDial/getForceFreshDial, checked in dialPeer, to unconditionally bypass the healthy-conn reuse for one dial attempt so such a caller can force a fresh dial.